### PR TITLE
Add a option to specify the control unix-domain socket location

### DIFF
--- a/src/client/lldpcli.8
+++ b/src/client/lldpcli.8
@@ -23,11 +23,13 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl dv
+.Op Fl u Ar file
 .Op Fl f Ar format
 .Op Fl c Ar file
 .Op Ar command ...
 .Nm lldpctl
 .Op Fl dv
+.Op Fl u Ar file
 .Op Fl f Ar format
 .Op Ar interfaces ...
 .Sh DESCRIPTION
@@ -47,6 +49,9 @@ The options are as follows:
 .Bl -tag -width Ds
 .It Fl d
 Enable more debugging information.
+.It Fl u
+Specify the Unix-domain socket used for communication with
+.Xr lldpd 8 .
 .It Fl v
 Show
 .Nm

--- a/src/client/lldpcli.c
+++ b/src/client/lldpcli.c
@@ -66,6 +66,7 @@ usage()
 	fprintf(stderr, "\n");
 
 	fprintf(stderr, "-d          Enable more debugging information.\n");
+	fprintf(stderr, "-u          Specify the Unix-domain socket used for communication with lldpd(8).\n");
 	fprintf(stderr, "-f format   Choose output format (plain, keyvalue or xml).\n");
 	if (!is_lldpctl(NULL))
 		fprintf(stderr, "-c          Read the provided configuration file.\n");
@@ -412,6 +413,7 @@ main(int argc, char *argv[])
 	lldpctl_conn_t *conn = NULL;
 	const char *options = is_lldpctl(argv[0])?"hdvf:":"hdsvf:c:";
 
+	const char *ctlname = lldpctl_get_default_transport();
 	int gotinputs = 0;
 	struct inputs inputs;
 	TAILQ_INIT(&inputs);
@@ -434,6 +436,9 @@ main(int argc, char *argv[])
 		case 'h':
 			usage();
 			break;
+		case 'u':
+			ctlname = optarg;
+			break;
 		case 'v':
 			fprintf(stdout, "%s\n", PACKAGE_VERSION);
 			exit(0);
@@ -455,7 +460,7 @@ main(int argc, char *argv[])
 
 	/* Make a connection */
 	log_debug("lldpctl", "connect to lldpd");
-	conn = lldpctl_new(NULL, NULL, NULL);
+	conn = lldpctl_new_name(ctlname, NULL, NULL, NULL);
 	if (conn == NULL) goto end;
 
 	/* Process file inputs */

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -36,7 +36,7 @@
  * @return The socket when successful, -1 otherwise.
  */
 int
-ctl_create(char *name)
+ctl_create(const char *name)
 {
 	int s;
 	struct sockaddr_un su;
@@ -69,7 +69,7 @@ ctl_create(char *name)
  * @return The socket when successful, -1 otherwise.
  */
 int
-ctl_connect(char *name)
+ctl_connect(const char *name)
 {
 	int s;
 	struct sockaddr_un su;
@@ -96,7 +96,7 @@ ctl_connect(char *name)
  * @param name The name of the Unix socket.
  */
 void
-ctl_cleanup(char *name)
+ctl_cleanup(const char *name)
 {
 	log_debug("control", "cleanup control socket");
 	if (unlink(name) == -1)

--- a/src/ctl.h
+++ b/src/ctl.h
@@ -47,9 +47,9 @@ struct hmsg_header {
 #define HMSG_MAX_SIZE (1<<19)
 
 /* ctl.c */
-int	 ctl_create(char *);
-int	 ctl_connect(char *);
-void	 ctl_cleanup(char *);
+int	 ctl_create(const char *);
+int	 ctl_connect(const char *);
+void	 ctl_cleanup(const char *);
 
 int	 ctl_msg_send_unserialized(uint8_t **, size_t *,
 				       enum hmsg_type,

--- a/src/daemon/lldpd.8
+++ b/src/daemon/lldpd.8
@@ -27,6 +27,7 @@
 .Op Fl P Ar platform
 .Op Fl X Ar socket
 .Op Fl m Ar management
+.Op Fl u Ar file
 .Op Fl I Ar interfaces
 .Op Fl C Ar interfaces
 .Op Fl M Ar class
@@ -183,6 +184,9 @@ only negative patterns are provided, only one IPv4 and one IPv6
 addresses are chosen. Otherwise, many of them can be selected. If you
 want to blacklist IPv6 addresses, you can use
 .Em !*:* .
+.It Fl u Ar file
+Specify the Unix-domain socket used for communication with
+.Xr lldpctl 8 .
 .It Fl I Ar interfaces
 Specify which interface to listen to. Without this option,
 .Nm

--- a/src/daemon/lldpd.h
+++ b/src/daemon/lldpd.h
@@ -105,6 +105,7 @@ struct lldpd {
 #endif /* USE_SNMP */
 
 	/* Unix socket handling */
+	const char		*g_ctlname;
 	int			 g_ctl;
 	struct event		*g_ctl_event;
 	struct event		*g_iface_event; /* Triggered when there is an interface change */
@@ -202,7 +203,7 @@ client_handle_client(struct lldpd *cfg,
 
 /* priv.c */
 void	 priv_init(const char*, int, uid_t, gid_t);
-void	 priv_ctl_cleanup(void);
+void	 priv_ctl_cleanup(const char *ctlname);
 char   	*priv_gethostbyname(void);
 #ifdef HOST_OS_LINUX
 int    	 priv_open(char*);

--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -178,6 +178,24 @@ lldpctl_conn_t *lldpctl_new(lldpctl_send_callback send,
     lldpctl_recv_callback recv, void *user_data);
 
 /**
+ * Allocate a new handler for connecting to lldpd.
+ *
+ * @param  ctlname   the Unix-domain socket to connect to lldpd.
+ * @param  send      Callback to be used when sending   new data is requested.
+ * @param  recv      Callback to be used when receiving new data is requested.
+ * @param  user_data Data to pass to callbacks.
+ * @return An handler to be used to connect to lldpd or @c NULL in
+ *         case of error. In the later case, the error is probable an
+ *         out of memory condition.
+ *
+ * The allocated handler can be released with @c lldpctl_release(). If the
+ * provided parameters are both @c NULL, default synchronous callbacks will be
+ * used.
+ */
+lldpctl_conn_t *lldpctl_new_name(const char *ctlname, lldpctl_send_callback send,
+    lldpctl_recv_callback recv, void *user_data);
+
+/**
  * Release resources associated with a connection to lldpd.
  *
  * @param   conn Previously allocated handler to a connection to lldpd.

--- a/src/lib/private.h
+++ b/src/lib/private.h
@@ -22,6 +22,9 @@
 
 /* connection.c */
 struct lldpctl_conn_t {
+	/* the Unix-domain socket to connect to lldpd */
+	const char *ctlname;
+
 	/* Callback handling */
 	lldpctl_recv_callback recv; /* Receive callback */
 	lldpctl_send_callback send; /* Send callback */


### PR DESCRIPTION
Hi:
  I use netns to create multiple network namespaces, and want to use lldp in all namespaces, so I need one lldp instance per namespace. but currently there is a unconfigurable global control unix socket which prevent me from creating multiple lldpd instance. I create this patch to solve the problem.
