### PR TITLE
lldpd: Make sure that the pidfile is created after forking for privilege separation

### DIFF
--- a/src/daemon/lldpd.h
+++ b/src/daemon/lldpd.h
@@ -220,7 +220,7 @@ client_handle_client(struct lldpd *cfg,
     int*);
 
 /* priv.c */
-void	 priv_init(const char*, int, uid_t, gid_t);
+void	 priv_init(const char*, int, uid_t, gid_t, int);
 void	 priv_wait(void);
 void	 priv_ctl_cleanup(const char *ctlname);
 char   	*priv_gethostbyname(void);


### PR DESCRIPTION
Currently when privilege is enabled, the pidfile contains the PID for the pre-fork PID. This causes any init system that relies on pidfiles to always fail to stop the daemon. This moves creation into the priv_init function, using an extra parameter to control whether it gets created or not.

This also moves starting of lldpcli to after daemonization on systems where daemonization is enabled.
