### PR TITLE
cdp: Fix newline in the middle of SysDescr

### DIFF
--- a/src/daemon/cdp.c
+++ b/src/daemon/cdp.c
@@ -544,7 +544,7 @@ cdp_decode(struct lldpd *cfg, char *frame, int s,
 		}
 		memcpy(chassis->c_descr, software, software_len);
 	} else if (software && platform) {
-#define CONCAT_PLATFORM " running on\n"
+#define CONCAT_PLATFORM " running on "
 		if ((chassis->c_descr = (char *)calloc(1,
 			    software_len + platform_len +
 			    strlen(CONCAT_PLATFORM) + 1)) == NULL) {


### PR DESCRIPTION
Currently the neighbour list looks like:

```
  Chassis:     
    ChassisID:    local ST-U2
    SysName:      ST-U2
    SysDescr:     N5N running on
XW.v5.5.7
    MgmtIP:       10.128.1.2
```
