### PR TITLE
Allow setting control socket on CLI

### DIFF
--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -1291,7 +1291,7 @@ lldpd_main(int argc, char *argv[], char *envp[])
 	int snmp = 0;
 	const char *agentx = NULL;	/* AgentX socket */
 #endif
-	const char *ctlname = LLDPD_CTL_SOCKET;
+	const char *ctlname = NULL;
 	char *mgmtp = NULL;
 	char *cidp = NULL;
 	char *interfaces = NULL;
@@ -1454,6 +1454,10 @@ lldpd_main(int argc, char *argv[], char *envp[])
 				usage();
 		}
 	}
+
+    if ( ctlname == NULL ) {
+        ctlname = LLDPD_CTL_SOCKET;
+    }
 
 	/* Set correct smart mode */
 	for (i=0; (filters[i].a != -1) && (filters[i].a != smart); i++);


### PR DESCRIPTION
Currently the if statement on line 1364 will always be true because ctlname is set on line 1294 and thus there isn't a way to specify the control socket on the CLI.
