### PR TITLE
lldpd: implement basic port label matching for interface names

### DIFF
--- a/src/client/conf-lldp.c
+++ b/src/client/conf-lldp.c
@@ -167,6 +167,14 @@ register_commands_configure_lldp(struct cmd_node *configure)
 				NEWLINE, NULL,
 				NULL, cmd_portid_type,
 				b_map->string);
+		} else if (!strcmp(b_map->string, "port")) {
+			commands_new(
+				commands_new(configure_lldp_portid_type,
+					     b_map->string, "Port Label/ID",
+					     NULL, NULL, NULL),
+				NEWLINE, NULL,
+				NULL, cmd_portid_type,
+				b_map->string);
 		} else if (!strcmp(b_map->string, "macaddress")) {
 			commands_new(
 				commands_new(configure_lldp_portid_type,

--- a/src/lib/atom-private.c
+++ b/src/lib/atom-private.c
@@ -54,7 +54,7 @@ static lldpctl_map_t port_id_subtype_map[] = {
 	{ LLDP_PORTID_SUBTYPE_LOCAL,    "local" },
 	{ LLDP_PORTID_SUBTYPE_LLADDR,   "mac" },
 	{ LLDP_PORTID_SUBTYPE_ADDR,     "ip" },
-	{ LLDP_PORTID_SUBTYPE_PORT,     "unhandled" },
+	{ LLDP_PORTID_SUBTYPE_PORT,     "port" },
 	{ LLDP_PORTID_SUBTYPE_AGENTCID, "unhandled" },
 	{ 0, NULL},
 };
@@ -273,6 +273,7 @@ static lldpctl_map_t bond_slave_src_mac_map[] = {
 static lldpctl_map_t lldp_portid_map[] = {
 	{ LLDP_PORTID_SUBTYPE_IFNAME,   "ifname"},
 	{ LLDP_PORTID_SUBTYPE_LLADDR,   "macaddress"},
+	{ LLDP_PORTID_SUBTYPE_PORT,     "port"},
 	{ LLDP_PORTID_SUBTYPE_UNKNOWN,  NULL},
 };
 
@@ -932,6 +933,7 @@ _lldpctl_atom_get_str_port(lldpctl_atom_t *atom, lldpctl_key_t key)
 		switch (port->p_id_subtype) {
 		case LLDP_PORTID_SUBTYPE_IFNAME:
 		case LLDP_PORTID_SUBTYPE_IFALIAS:
+		case LLDP_PORTID_SUBTYPE_PORT:
 		case LLDP_PORTID_SUBTYPE_LOCAL:
 			return port->p_id;
 		case LLDP_PORTID_SUBTYPE_LLADDR:


### PR DESCRIPTION
This is a RFC for an implementation of basic port labelling
without the use of any LLDP extensions (like LLDP-MED, DOT1 & DOT3).

The way this works is:
- added a new 'portidsubtype' to the command:
   'configure portidsubtype ifname ifname | macaddress | port'
- by default 'port' is the new 'portidsubtype'
  - if there is a file present called '/etc/lldpd.labels' then
    a label is searched in that file for a given ifname
  - if there is no file, or no port label was found, the 'macaddress'
    is used as fallback
- in that file, ifnames must be matched to 'label'
  example:
    eth0=BLUE_NET
    eth1=RED_NET
    eth2=MAGIC_PORT
    ...
  Note that the parsing of this file is not very fault tolerant to spaces
  In essence, a process would set this to the file, and lldpd could be
  restarted to broadcast this info, having Port IDs that match to physical
  ports/cables/setups.
- internally, the LLDP_PORTID_SUBTYPE_PORT value is used, since it looked unused
  for desired for future use; alternative would have been to add
  a LLDP_PORTID_SUBTYPE_LABEL, or rename to this from LLDP_PORTID_SUBTYPE_PORT

Note: if chroot, be sure to put the file in the chroot location.
      example: if chroot is '/var/run/lldp', then the labels should be
               in '/var/run/lldp/etc/lldpd.labels'

I'm not looking for this to be final/official implementation that allows
us to override Port IDs to anything other than ifname and/or macaddress,
but we do need something like this.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>