### PR TITLE
Make some TLVs optional

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -128,7 +128,7 @@ void register_commands_watch(struct cmd_node *);
 /* conf*.c */
 void register_commands_configure(struct cmd_node *);
 void register_commands_configure_system(struct cmd_node *, struct cmd_node *);
-void register_commands_configure_lldp(struct cmd_node *);
+void register_commands_configure_lldp(struct cmd_node *, struct cmd_node *);
 void register_commands_configure_med(struct cmd_node *, struct cmd_node *);
 void register_commands_configure_dot3(struct cmd_node *);
 void register_commands_medpow(struct cmd_node *);

--- a/src/client/conf-lldp.c
+++ b/src/client/conf-lldp.c
@@ -77,6 +77,8 @@ cmd_portid_type_local(struct lldpctl_conn_t *conn, struct writer *w,
 	const char *id = cmdenv_get(env, "port-id");
 	const char *descr = cmdenv_get(env, "port-descr");
 
+	log_debug("lldpctl", "lldp PortID TLV Subtype Local port-id '%s' port-descr '%s'", id, descr);
+
 	if (!id || !strlen(id)) {
 		log_warnx("lldpctl", "no id speficied");
 		return 0;
@@ -149,6 +151,8 @@ static int
 cmd_chassis_cap_advertise(struct lldpctl_conn_t *conn, struct writer *w,
     struct cmd_env *env, void *arg)
 {
+	log_debug("lldpctl", "lldp capabilities-advertisements %s", arg?"enable":"disable");
+
 	lldpctl_atom_t *config = lldpctl_get_configuration(conn);
 	if (config == NULL) {
 		log_warnx("lldpctl", "unable to get configuration from lldpd. %s",
@@ -175,6 +179,8 @@ static int
 cmd_chassis_mgmt_advertise(struct lldpctl_conn_t *conn, struct writer *w,
     struct cmd_env *env, void *arg)
 {
+	log_debug("lldpctl", "lldp management-addresses-advertisements %s", arg?"enable":"disable");
+
 	lldpctl_atom_t *config = lldpctl_get_configuration(conn);
 	if (config == NULL) {
 		log_warnx("lldpctl", "unable to get configuration from lldpd. %s",

--- a/src/client/conf.c
+++ b/src/client/conf.c
@@ -43,7 +43,7 @@ register_commands_configure(struct cmd_node *root)
 	cmd_restrict_ports(unconfigure);
 
 	register_commands_configure_system(configure, unconfigure);
-	register_commands_configure_lldp(configure);
+	register_commands_configure_lldp(configure, unconfigure);
 	register_commands_configure_med(configure, unconfigure);
 	register_commands_configure_dot3(configure);
 }

--- a/src/daemon/client.c
+++ b/src/daemon/client.c
@@ -162,6 +162,12 @@ client_handle_set_configuration(struct lldpd *cfg, enum hmsg_type *type,
 		cfg->g_config.c_promisc = config->c_promisc;
 		levent_update_now(cfg);
 	}
+	if (CHANGED(c_cap_advertise)) {
+		log_debug("rpc", "%s chassis capabilities advertisement",
+		    config->c_promisc?"enable":"disable");
+		cfg->g_config.c_cap_advertise = config->c_cap_advertise;
+		levent_update_now(cfg);
+	}
 	if (CHANGED(c_bond_slave_src_mac_type)) {
 		if (config->c_bond_slave_src_mac_type >
 		    LLDP_BOND_SLAVE_SRC_MAC_TYPE_UNKNOWN &&

--- a/src/daemon/client.c
+++ b/src/daemon/client.c
@@ -168,6 +168,12 @@ client_handle_set_configuration(struct lldpd *cfg, enum hmsg_type *type,
 		cfg->g_config.c_cap_advertise = config->c_cap_advertise;
 		levent_update_now(cfg);
 	}
+	if (CHANGED(c_mgmt_advertise)) {
+		log_debug("rpc", "%s management addresses advertisement",
+		    config->c_promisc?"enable":"disable");
+		cfg->g_config.c_mgmt_advertise = config->c_mgmt_advertise;
+		levent_update_now(cfg);
+	}
 	if (CHANGED(c_bond_slave_src_mac_type)) {
 		if (config->c_bond_slave_src_mac_type >
 		    LLDP_BOND_SLAVE_SRC_MAC_TYPE_UNKNOWN &&

--- a/src/daemon/interfaces.c
+++ b/src/daemon/interfaces.c
@@ -439,6 +439,8 @@ interfaces_helper_mgmt(struct lldpd *cfg,
 	const char *pattern = cfg->g_config.c_mgmt_pattern;
 
 	lldpd_chassis_mgmt_cleanup(LOCAL_CHASSIS(cfg));
+	if (!cfg->g_config.c_mgmt_advertise)
+		return;
 
 	/* Is the pattern provided an actual IP address? */
 	if (pattern && strpbrk(pattern, "!,*?") == NULL) {

--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -1638,6 +1638,7 @@ lldpd_main(int argc, char *argv[], char *envp[])
 	if ((lchassis = (struct lldpd_chassis*)
 		calloc(1, sizeof(struct lldpd_chassis))) == NULL)
 		fatal("localchassis", NULL);
+	cfg->g_config.c_cap_advertise = 1;
 	lchassis->c_cap_available = LLDP_CAP_BRIDGE | LLDP_CAP_WLAN |
 	    LLDP_CAP_ROUTER | LLDP_CAP_STATION;
 	TAILQ_INIT(&lchassis->c_mgmt);

--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -1700,6 +1700,7 @@ lldpd_main(int argc, char *argv[], char *envp[])
 	log_debug("main", "start main loop");
 	levent_loop(cfg);
 	lldpd_exit(cfg);
+	free(cfg);
 
 	return (0);
 }

--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -1641,6 +1641,7 @@ lldpd_main(int argc, char *argv[], char *envp[])
 	cfg->g_config.c_cap_advertise = 1;
 	lchassis->c_cap_available = LLDP_CAP_BRIDGE | LLDP_CAP_WLAN |
 	    LLDP_CAP_ROUTER | LLDP_CAP_STATION;
+	cfg->g_config.c_mgmt_advertise = 1;
 	TAILQ_INIT(&lchassis->c_mgmt);
 #ifdef ENABLE_LLDPMED
 	if (lldpmed > 0) {

--- a/src/daemon/protocols/lldp.c
+++ b/src/daemon/protocols/lldp.c
@@ -146,7 +146,7 @@ static int _lldp_send(struct lldpd *global,
 	}
 
 	/* System capabilities */
-	if (chassis->c_cap_available) {
+	if (global->g_config.c_cap_advertise && chassis->c_cap_available) {
 		if (!(
 			    POKE_START_LLDP_TLV(LLDP_TLV_SYSTEM_CAP) &&
 			    POKE_UINT16(chassis->c_cap_available) &&

--- a/src/daemon/protocols/lldp.c
+++ b/src/daemon/protocols/lldp.c
@@ -146,12 +146,14 @@ static int _lldp_send(struct lldpd *global,
 	}
 
 	/* System capabilities */
-	if (!(
-	      POKE_START_LLDP_TLV(LLDP_TLV_SYSTEM_CAP) &&
-	      POKE_UINT16(chassis->c_cap_available) &&
-	      POKE_UINT16(chassis->c_cap_enabled) &&
-	      POKE_END_LLDP_TLV))
-		goto toobig;
+	if (chassis->c_cap_available) {
+		if (!(
+			    POKE_START_LLDP_TLV(LLDP_TLV_SYSTEM_CAP) &&
+			    POKE_UINT16(chassis->c_cap_available) &&
+			    POKE_UINT16(chassis->c_cap_enabled) &&
+			    POKE_END_LLDP_TLV))
+			goto toobig;
+	}
 
 	/* Management addresses */
 	TAILQ_FOREACH(mgmt, &chassis->c_mgmt, m_entries) {

--- a/src/lib/atoms/config.c
+++ b/src/lib/atoms/config.c
@@ -201,6 +201,8 @@ _lldpctl_atom_get_int_config(lldpctl_atom_t *atom, lldpctl_key_t key)
 		return c->config->c_set_ifdescr;
 	case lldpctl_k_config_iface_promisc:
 		return c->config->c_promisc;
+	case lldpctl_k_config_chassis_cap_advertise:
+		return c->config->c_cap_advertise;
 #ifdef ENABLE_LLDPMED
 	case lldpctl_k_config_lldpmed_noinventory:
 		return c->config->c_noinventory;
@@ -240,6 +242,9 @@ _lldpctl_atom_set_int_config(lldpctl_atom_t *atom, lldpctl_key_t key,
 		break;
 	case lldpctl_k_config_iface_promisc:
 		config.c_promisc = c->config->c_promisc = value;
+		break;
+	case lldpctl_k_config_chassis_cap_advertise:
+		config.c_cap_advertise = c->config->c_cap_advertise = value;
 		break;
 #ifdef ENABLE_LLDPMED
 	case lldpctl_k_config_fast_start_enabled:

--- a/src/lib/atoms/config.c
+++ b/src/lib/atoms/config.c
@@ -203,6 +203,8 @@ _lldpctl_atom_get_int_config(lldpctl_atom_t *atom, lldpctl_key_t key)
 		return c->config->c_promisc;
 	case lldpctl_k_config_chassis_cap_advertise:
 		return c->config->c_cap_advertise;
+	case lldpctl_k_config_chassis_mgmt_advertise:
+		return c->config->c_mgmt_advertise;
 #ifdef ENABLE_LLDPMED
 	case lldpctl_k_config_lldpmed_noinventory:
 		return c->config->c_noinventory;
@@ -245,6 +247,9 @@ _lldpctl_atom_set_int_config(lldpctl_atom_t *atom, lldpctl_key_t key,
 		break;
 	case lldpctl_k_config_chassis_cap_advertise:
 		config.c_cap_advertise = c->config->c_cap_advertise = value;
+		break;
+	case lldpctl_k_config_chassis_mgmt_advertise:
+		config.c_mgmt_advertise = c->config->c_mgmt_advertise = value;
 		break;
 #ifdef ENABLE_LLDPMED
 	case lldpctl_k_config_fast_start_enabled:

--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -613,6 +613,7 @@ typedef enum {
 	lldpctl_k_config_ifdescr_update, /**< `(I,WO)` Enable or disable setting interface description */
 	lldpctl_k_config_iface_promisc,  /**< `(I,WO)` Enable or disable promiscuous mode on interfaces */
 	lldpctl_k_config_chassis_cap_advertise, /**< `(I,WO)` Enable or disable chassis capabilities advertisement */
+	lldpctl_k_config_chassis_mgmt_advertise, /**< `(I,WO)` Enable or disable management addresses advertisement */
 
 	lldpctl_k_interface_name = 1000, /**< `(S)` The interface name. */
 

--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -612,6 +612,7 @@ typedef enum {
 	lldpctl_k_config_fast_start_interval, /**< `(I,WO)` Start fast transmit interval */
 	lldpctl_k_config_ifdescr_update, /**< `(I,WO)` Enable or disable setting interface description */
 	lldpctl_k_config_iface_promisc,  /**< `(I,WO)` Enable or disable promiscuous mode on interfaces */
+	lldpctl_k_config_chassis_cap_advertise, /**< `(I,WO)` Enable or disable chassis capabilities advertisement */
 
 	lldpctl_k_interface_name = 1000, /**< `(S)` The interface name. */
 

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -331,6 +331,7 @@ struct lldpd_config {
 	int c_advertise_version; /* Should the precise version be advertised? */
 	int c_set_ifdescr;	 /* Set interface description */
 	int c_promisc;		 /* Interfaces should be in promiscuous mode */
+	int c_cap_advertise;	 /* Chassis capabilities advertisement */
 
 #ifdef ENABLE_LLDPMED
 	int c_noinventory;	/* Don't send inventory with LLDP-MED */

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -332,6 +332,7 @@ struct lldpd_config {
 	int c_set_ifdescr;	 /* Set interface description */
 	int c_promisc;		 /* Interfaces should be in promiscuous mode */
 	int c_cap_advertise;	 /* Chassis capabilities advertisement */
+	int c_mgmt_advertise;	 /* Management addresses advertisement */
 
 #ifdef ENABLE_LLDPMED
 	int c_noinventory;	/* Don't send inventory with LLDP-MED */

--- a/tests/check_lldp.c
+++ b/tests/check_lldp.c
@@ -24,6 +24,13 @@
 
 char filenameprefix[] = "lldp_send";
 
+static struct lldpd test_lldpd = {
+	.g_config = {
+		.c_cap_advertise     = 1,  /* Chassis capabilities advertisement */
+		.c_mgmt_advertise    = 1,  /* Management addresses advertisement */
+	}
+};
+
 #define ck_assert_str_eq_n(X, Y, N) \
 	ck_assert_msg(!strncmp(X, Y, N), "Assertion '"#X"=="#Y"' failed: "#X"==\"%s\", "#Y"==\"%s\"", X, Y)
 
@@ -154,7 +161,7 @@ START_TEST (test_send_rcv_basic)
 	chassis.c_cap_available = chassis.c_cap_enabled = LLDP_CAP_ROUTER;
 
 	/* Build packet */
-	n = lldp_send(NULL, &hardware);
+	n = lldp_send(&test_lldpd, &hardware);
 	if (n != 0) {
 		fail("unable to build packet");
 		return;
@@ -225,7 +232,7 @@ START_TEST (test_send_rcv_dot1_tlvs)
 	TAILQ_INSERT_TAIL(&hardware.h_lport.p_pids, &pi2, p_entries);
 
 	/* Build packet */
-	n = lldp_send(NULL, &hardware);
+	n = lldp_send(&test_lldpd, &hardware);
 	if (n != 0) {
 		fail("unable to build packet");
 		return;
@@ -363,7 +370,7 @@ START_TEST (test_send_rcv_med)
 	hardware.h_lport.p_med_power.val = 65;
 
 	/* Build packet */
-	n = lldp_send(NULL, &hardware);
+	n = lldp_send(&test_lldpd, &hardware);
 	if (n != 0) {
 		fail("unable to build packet");
 		return;
@@ -423,7 +430,7 @@ START_TEST (test_send_rcv_dot3)
 	chassis.c_cap_available = chassis.c_cap_enabled = LLDP_CAP_ROUTER | LLDP_CAP_WLAN;
 
 	/* Build packet */
-	n = lldp_send(NULL, &hardware);
+	n = lldp_send(&test_lldpd, &hardware);
 	if (n != 0) {
 		fail("unable to build packet");
 		return;


### PR DESCRIPTION
Specifically, the Chassis Capabilities and Management IP addresses.
For our case they are not needed.

This change allows lldpcli to disable them by calling
```
unconfigure lldp capabilities-advertisements
unconfigure lldp management-addresses-advertisements
```

Any comments/objections/preferences are welcome for changing some namings.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>