### PR TITLE
Add support for custom TLVs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - LLDPD_CONFIG_ARGS="--with-embedded-libevent"
     - LLDPD_CONFIG_ARGS="--disable-privsep --with-snmp"
     - LLDPD_CONFIG_ARGS="--with-snmp --with-xml --with-json --disable-lldpmed --disable-dot1 --disable-dot3"
+    - LLDPD_CONFIG_ARGS="--with-snmp --with-xml --with-json --disable-lldpmed --disable-dot1 --disable-dot3 --disable-custom"
 matrix:
   include:
     - os: linux

--- a/configure.ac
+++ b/configure.ac
@@ -276,6 +276,7 @@ lldp_ARG_ENABLE([sonmp], [SynOptics Network Management Protocol], [yes])
 lldp_ARG_ENABLE([lldpmed], [LLDP-MED extension], [yes])
 lldp_ARG_ENABLE([dot1], [Dot1 extension (VLAN stuff)], [yes])
 lldp_ARG_ENABLE([dot3], [Dot3 extension (PHY stuff)], [yes])
+lldp_ARG_ENABLE([custom], [Custom TLV support], [yes])
 
 # Oldies
 lldp_ARG_ENABLE([oldies], [compatibility with Linux kernel older than 2.6.18], [no])
@@ -319,6 +320,7 @@ cat <<EOF
   LLDPMED........: $enable_lldpmed
   DOT1...........: $enable_dot1
   DOT3...........: $enable_dot3
+  CUSTOM.........: $enable_custom
   XML output.....: ${with_xml-no}
   JSON output....: ${with_json-no}
   Oldies support.: $enable_oldies

--- a/redhat/lldpd.spec
+++ b/redhat/lldpd.spec
@@ -14,6 +14,7 @@
 %bcond_without lldpmed
 %bcond_without dot1
 %bcond_without dot3
+%bcond_without custom
 
 # On RHEL < 5, disable SNMP, Net-SNMP installation seems broken
 %if 0%{?rhel_version} > 0 && 0%{?rhel_version} < 500 || 0%{?centos_version} > 0 && 0%{?centos_version} < 500
@@ -137,6 +138,11 @@ to adjacent network devices.
    --enable-dot3 \
 %else
    --disable-dot3 \
+%endif
+%if %{with custom}
+   --enable-custom \
+%else
+   --disable-custom \
 %endif
    --with-privsep-user=%lldpd_user \
    --with-privsep-group=%lldpd_group \

--- a/src/client/conf-lldp.c
+++ b/src/client/conf-lldp.c
@@ -202,6 +202,7 @@ cmd_chassis_mgmt_advertise(struct lldpctl_conn_t *conn, struct writer *w,
 	return 1;
 }
 
+#ifdef ENABLE_CUSTOM
 static int
 cmd_custom_tlv_set(struct lldpctl_conn_t *conn, struct writer *w,
         struct cmd_env *env, void *arg)
@@ -325,6 +326,7 @@ register_commands_configure_lldp_custom_tlvs(struct cmd_node *configure_lldp)
 		NEWLINE, "Add custom TLV(s) to be broadcast on ports",
 		NULL, cmd_custom_tlv_set, "enable");
 }
+#endif /* ENABLE_CUSTOM */
 
 /**
  * Register `configure lldp` commands.
@@ -445,6 +447,7 @@ register_commands_configure_lldp(struct cmd_node *configure,
 		NULL, cmd_chassis_mgmt_advertise, NULL);
 
 
+#ifdef ENABLE_CUSTOM
 	register_commands_configure_lldp_custom_tlvs(configure_lldp);
 	commands_new(
 		commands_new(unconfigure_lldp,
@@ -453,4 +456,5 @@ register_commands_configure_lldp(struct cmd_node *configure,
 			NULL, NULL, NULL),
 		NEWLINE, "Clear all (previously set) custom TLVs",
 		NULL, cmd_custom_tlv_set, NULL);
+#endif
 }

--- a/src/client/conf-lldp.c
+++ b/src/client/conf-lldp.c
@@ -202,6 +202,130 @@ cmd_chassis_mgmt_advertise(struct lldpctl_conn_t *conn, struct writer *w,
 	return 1;
 }
 
+static int
+cmd_custom_tlv_set(struct lldpctl_conn_t *conn, struct writer *w,
+        struct cmd_env *env, void *arg)
+{
+	lldpctl_atom_t *iface;
+	const char *s;
+	uint8_t oui[LLDP_TLV_ORG_OUI_LEN];
+	uint8_t oui_info[LLDP_TLV_ORG_OUI_INFO_MAXLEN];
+	int oui_info_len = 0;
+	uint16_t subtype = 0;
+
+	log_debug("lldpctl", "lldp custom-tlv(s) %s", arg?"set":"clear");
+
+	if (!arg)
+		goto set;
+
+	s = cmdenv_get(env, "oui");
+	if (!s || (
+	    sscanf(s, "%02hhx,%02hhx,%02hhx", &oui[0], &oui[1], &oui[2]) != 3 &&
+	    sscanf(s, "%02hhX,%02hhX,%02hhX", &oui[0], &oui[1], &oui[2]) != 3) ) {
+		log_warnx("lldpctl", "invalid OUI value '%s'", s);
+		return 0;
+	}
+
+	s = cmdenv_get(env, "subtype");
+	if (!s) {
+		log_warnx("lldpctl", "no subtype specified");
+		return 0;
+	} else {
+		subtype = (uint16_t)atoi(s);
+		if (subtype > 255) {
+			log_warnx("lldpctl", "invalid subtype range  value '%s'", s);
+			return 0;
+		}
+	}
+
+	s = cmdenv_get(env, "oui-info");
+	/* This info is optional */
+	if (s) {
+		const char delim[] = ",";
+		char *s_copy = strdup(s);
+		char *token = strtok(s_copy, delim);
+		while (token != NULL) {
+			if (sscanf(token, "%02hhx", &oui_info[oui_info_len]) == 1 ||
+			    sscanf(token, "%02hhX", &oui_info[oui_info_len]) == 1)
+				oui_info_len++;
+			if (oui_info_len >= sizeof(oui_info))
+				break;
+			token = strtok(NULL, delim);
+		}
+		free(s_copy);
+	}
+
+set:
+	while ((iface = cmd_iterate_on_interfaces(conn, env))) {
+		lldpctl_atom_t *port = lldpctl_get_port(iface);
+		lldpctl_atom_t *custom_tlvs;
+		if (!arg) {
+			lldpctl_atom_set(port, lldpctl_k_custom_tlvs_clear, NULL);
+		} else if (!(custom_tlvs = lldpctl_atom_get(port, lldpctl_k_custom_tlvs))) {
+			log_warnx("lldpctl", "unable to get custom TLVs for port");
+		} else {
+			lldpctl_atom_t *tlv = lldpctl_atom_create(custom_tlvs);
+			if (!tlv) {
+				log_warnx("lldpctl", "unable to create new custom TLV for port");
+			} else {
+				/* Configure custom TLV */
+				lldpctl_atom_set_buffer(tlv, lldpctl_k_custom_tlv_oui, oui, sizeof(oui));
+				lldpctl_atom_set_int(tlv, lldpctl_k_custom_tlv_oui_subtype, subtype);
+				lldpctl_atom_set_buffer(tlv, lldpctl_k_custom_tlv_oui_info_string, oui_info, oui_info_len);
+
+				/* Assign it to port */
+				lldpctl_atom_set(port, lldpctl_k_custom_tlv, tlv);
+			}
+		}
+		lldpctl_atom_dec_ref(port);
+	}
+
+	return 1;
+}
+
+void
+register_commands_configure_lldp_custom_tlvs(struct cmd_node *configure_lldp)
+{
+	struct cmd_node *configure_custom_tlvs;
+	struct cmd_node *configure_custom_tlvs_basic;
+
+	configure_custom_tlvs = 
+		commands_new(configure_lldp,
+			    "custom-tlv",
+			    "Add custom TLV(s) to be broadcast on ports",
+			    NULL, NULL, NULL);
+
+	/* Basic form: 'configure lldp oui 11,22,33 subtype 44' */
+	configure_custom_tlvs_basic = 
+		commands_new(
+			commands_new(
+				commands_new(
+					commands_new(configure_custom_tlvs,
+						"oui", "Organizationally Unique Identifier",
+						NULL, NULL, NULL),
+					NULL, "Organizationally Unique Identifier",
+					NULL, cmd_store_env_value, "oui"),
+				"subtype", "Organizationally Defined Subtype",
+				NULL, NULL, NULL),
+			NULL, "Organizationally Defined Subtype", 
+			NULL, cmd_store_env_value, "subtype");
+
+	commands_new(configure_custom_tlvs_basic,
+		NEWLINE, "Add custom TLV(s) to be broadcast on ports",
+		NULL, cmd_custom_tlv_set, "enable");
+
+	/* Extended form: 'configure lldp oui 11,22,33 subtype 44 oui-info 55,66,77,...' */
+	commands_new(
+		commands_new(
+			commands_new(configure_custom_tlvs_basic,
+				"oui-info", "Organizationally Unique Identifier",
+				NULL, NULL, NULL),
+			NULL, "OUI Info String", 
+			NULL, cmd_store_env_value, "oui-info"),
+		NEWLINE, "Add custom TLV(s) to be broadcast on ports",
+		NULL, cmd_custom_tlv_set, "enable");
+}
+
 /**
  * Register `configure lldp` commands.
  *
@@ -319,4 +443,14 @@ register_commands_configure_lldp(struct cmd_node *configure,
 		    NULL, NULL, NULL),
 		NEWLINE, "Don't enable management addresses advertisement",
 		NULL, cmd_chassis_mgmt_advertise, NULL);
+
+
+	register_commands_configure_lldp_custom_tlvs(configure_lldp);
+	commands_new(
+		commands_new(unconfigure_lldp,
+			"custom-tlvs",
+			"Clear all (previously set) custom TLVs",
+			NULL, NULL, NULL),
+		NEWLINE, "Clear all (previously set) custom TLVs",
+		NULL, cmd_custom_tlv_set, NULL);
 }

--- a/src/daemon/client.c
+++ b/src/daemon/client.c
@@ -369,6 +369,7 @@ client_handle_set_port(struct lldpd *cfg, enum hmsg_type *type,
 				sizeof(struct lldpd_dot3_power));
 		    }
 #endif
+#ifdef ENABLE_CUSTOM
 		    if (set->custom_list_clear) {
 			    log_debug("rpc", "requested custom TLVs clear");
 			    lldpd_custom_list_cleanup(port);
@@ -382,6 +383,7 @@ client_handle_set_port(struct lldpd *cfg, enum hmsg_type *type,
 			    } else
 				    log_warn("rpc", "could not allocate memory for custom TLV");
 		    }
+#endif
 
 		    ret = 1;
 		    break;

--- a/src/daemon/client.c
+++ b/src/daemon/client.c
@@ -369,6 +369,20 @@ client_handle_set_port(struct lldpd *cfg, enum hmsg_type *type,
 				sizeof(struct lldpd_dot3_power));
 		    }
 #endif
+		    if (set->custom_list_clear) {
+			    log_debug("rpc", "requested custom TLVs clear");
+			    lldpd_custom_list_cleanup(port);
+		    } else 
+		    if (set->custom) {
+			    struct lldpd_custom *custom;
+			    log_debug("rpc", "requested custom TLV add");
+			    if ((custom = malloc(sizeof(struct lldpd_custom)))) {
+				    memcpy(custom, set->custom, sizeof(struct lldpd_custom));
+				    TAILQ_INSERT_TAIL(&port->p_custom_list, custom, next);
+			    } else
+				    log_warn("rpc", "could not allocate memory for custom TLV");
+		    }
+
 		    ret = 1;
 		    break;
 	    }
@@ -391,6 +405,9 @@ set_port_finished:
 #endif
 #ifdef ENABLE_DOT3
 	free(set->dot3_power);
+#endif
+#ifdef ENABLE_CUSTOM
+	free(set->custom);
 #endif
 	return 0;
 }

--- a/src/daemon/lldp-tlv.h
+++ b/src/daemon/lldp-tlv.h
@@ -31,7 +31,6 @@
 #define LLDP_TLV_SYSTEM_DESCR	6
 #define LLDP_TLV_SYSTEM_CAP	7
 #define LLDP_TLV_MGMT_ADDR	8
-#define LLDP_TLV_ORG		127
 
 #define LLDP_TLV_ORG_DOT1	{0x00, 0x80, 0xc2}
 #define LLDP_TLV_ORG_DOT3	{0x00, 0x12, 0x0f}

--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -169,6 +169,7 @@ lldpd_alloc_hardware(struct lldpd *cfg, char *name, int index)
 	TAILQ_INIT(&hardware->h_lport.p_ppvids);
 	TAILQ_INIT(&hardware->h_lport.p_pids);
 #endif
+	TAILQ_INIT(&hardware->h_lport.p_custom_list);
 
 	levent_hardware_init(hardware);
 	return hardware;

--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -169,7 +169,9 @@ lldpd_alloc_hardware(struct lldpd *cfg, char *name, int index)
 	TAILQ_INIT(&hardware->h_lport.p_ppvids);
 	TAILQ_INIT(&hardware->h_lport.p_pids);
 #endif
+#ifdef ENABLE_CUSTOM
 	TAILQ_INIT(&hardware->h_lport.p_custom_list);
+#endif
 
 	levent_hardware_init(hardware);
 	return hardware;

--- a/src/daemon/protocols/lldp.c
+++ b/src/daemon/protocols/lldp.c
@@ -1106,8 +1106,12 @@ lldp_decode(struct lldpd *cfg, char *frame, int s,
 				custom->oui_info_len = tlv_size > 4 ? tlv_size - 4 : 0;
 				memcpy(custom->oui, orgid, sizeof(custom->oui));
 				custom->subtype = tlv_subtype;
-				if (custom->oui_info_len > 0)
+				if (custom->oui_info_len > 0) {
+					custom->oui_info = malloc(custom->oui_info_len);
+					if (!custom->oui_info)
+						return ENOMEM;
 					PEEK_BYTES(custom->oui_info, custom->oui_info_len);
+				}
 				TAILQ_INSERT_TAIL(&port->p_custom_list, custom, next);
 #endif
 			}

--- a/src/daemon/protocols/lldp.c
+++ b/src/daemon/protocols/lldp.c
@@ -1074,7 +1074,7 @@ lldp_decode(struct lldpd *cfg, char *frame, int s,
 				    hardware->h_ifname);
 				hardware->h_rx_unrecognized_cnt++;
 			} else {
-				log_info("lldp", "unknown org tlv [%02x:%02x:%02x] received on %s",
+				log_debug("lldp", "unknown org tlv [%02x:%02x:%02x] received on %s",
 				    orgid[0], orgid[1], orgid[2],
 				    hardware->h_ifname);
 				hardware->h_rx_unrecognized_cnt++;

--- a/src/daemon/protocols/lldp.c
+++ b/src/daemon/protocols/lldp.c
@@ -84,7 +84,9 @@ static int _lldp_send(struct lldpd *global,
 	int i;
 	const u_int8_t med[] = LLDP_TLV_ORG_MED;
 #endif
+#ifdef ENABLE_CUSTOM
 	struct lldpd_custom *custom;
+#endif
 	port = &hardware->h_lport;
 	chassis = port->p_chassis;
 	length = hardware->h_mtu;
@@ -432,6 +434,7 @@ static int _lldp_send(struct lldpd *global,
 	}
 #endif
 
+#ifdef ENABLE_CUSTOM
 	TAILQ_FOREACH(custom, &port->p_custom_list, next) {
 		if (!(
 		      POKE_START_LLDP_TLV(LLDP_TLV_ORG) &&
@@ -441,6 +444,7 @@ static int _lldp_send(struct lldpd *global,
 		      POKE_END_LLDP_TLV))
 			goto toobig;
 	}
+#endif
 
 end:
 	/* END */
@@ -590,7 +594,9 @@ lldp_decode(struct lldpd *cfg, char *frame, int s,
 	u_int8_t addr_str_length, addr_str_buffer[32];
 	u_int8_t addr_family, addr_length, *addr_ptr, iface_subtype;
 	u_int32_t iface_number, iface;
+#ifdef ENABLE_CUSTOM
 	struct lldpd_custom *custom;
+#endif
 
 	log_debug("lldp", "receive LLDP PDU on %s",
 	    hardware->h_ifname);
@@ -610,7 +616,9 @@ lldp_decode(struct lldpd *cfg, char *frame, int s,
 	TAILQ_INIT(&port->p_ppvids);
 	TAILQ_INIT(&port->p_pids);
 #endif
+#ifdef ENABLE_CUSTOM
 	TAILQ_INIT(&port->p_custom_list);
+#endif
 
 	length = s;
 	pos = (u_int8_t*)frame;
@@ -1091,6 +1099,7 @@ lldp_decode(struct lldpd *cfg, char *frame, int s,
 				    orgid[0], orgid[1], orgid[2],
 				    hardware->h_ifname);
 				hardware->h_rx_unrecognized_cnt++;
+#ifdef ENABLE_CUSTOM
 				custom = (struct lldpd_custom*)calloc(1, sizeof(struct lldpd_custom));
 				if (!custom)
 					return ENOMEM;
@@ -1100,6 +1109,7 @@ lldp_decode(struct lldpd *cfg, char *frame, int s,
 				if (custom->oui_info_len > 0)
 					PEEK_BYTES(custom->oui_info, custom->oui_info_len);
 				TAILQ_INSERT_TAIL(&port->p_custom_list, custom, next);
+#endif
 			}
 			break;
 		default:

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -11,7 +11,8 @@ libfixedpoint_la_SOURCES = fixedpoint.h fixedpoint.c
 liblldpctl_la_SOURCES = \
 	lldpctl.h atom.h errors.c connection.c atom.c helpers.c helpers.h \
 	atoms/config.c atoms/dot1.c atoms/dot3.c \
-	atoms/interface.c atoms/med.c atoms/mgmt.c atoms/port.c
+	atoms/interface.c atoms/med.c atoms/mgmt.c atoms/port.c \
+	atoms/custom.c
 liblldpctl_la_LIBADD  = $(top_builddir)/src/libcommon-daemon-lib.la libfixedpoint.la
 liblldpctl_la_LDFLAGS = $(AM_LDFLAGS) -export-symbols-regex '^lldpctl_' -version-info 10:0:6
 

--- a/src/lib/atom.c
+++ b/src/lib/atom.c
@@ -35,7 +35,8 @@ lldpctl_atom_get_connection(lldpctl_atom_t *atom)
 void
 lldpctl_atom_inc_ref(lldpctl_atom_t *atom)
 {
-	atom->count++;
+	if (atom)
+		atom->count++;
 }
 
 void

--- a/src/lib/atom.c
+++ b/src/lib/atom.c
@@ -22,7 +22,6 @@
 #include "../log.h"
 #include "../marshal.h"
 #include "../ctl.h"
-#include "../lldpd-structs.h"
 
 lldpctl_conn_t*
 lldpctl_atom_get_connection(lldpctl_atom_t *atom)

--- a/src/lib/atom.h
+++ b/src/lib/atom.h
@@ -16,6 +16,7 @@
  */
 
 #include <sys/queue.h>
+#include "../lldpd-structs.h"
 #include "../compat/compat.h"
 #include "../marshal.h"
 #include "../ctl.h"

--- a/src/lib/atom.h
+++ b/src/lib/atom.h
@@ -111,6 +111,8 @@ typedef enum {
 	atom_med_caelement,
 	atom_med_power,
 #endif
+	atom_custom_list,
+	atom_custom,
 } atom_t;
 
 void *_lldpctl_alloc_in_atom(lldpctl_atom_t *, size_t);
@@ -248,6 +250,18 @@ struct _lldpctl_atom_med_power_t {
 	struct _lldpctl_atom_port_t *parent;
 };
 #endif
+
+struct _lldpctl_atom_custom_list_t {
+	lldpctl_atom_t base;
+	struct _lldpctl_atom_port_t *parent;
+	struct lldpd_custom_list *list;
+};
+
+struct _lldpctl_atom_custom_t {
+	lldpctl_atom_t base;
+	struct _lldpctl_atom_port_t *parent;
+	struct lldpd_custom *tlv;
+};
 
 struct lldpctl_atom_t *_lldpctl_new_atom(lldpctl_conn_t *conn, atom_t type, ...);
 

--- a/src/lib/atom.h
+++ b/src/lib/atom.h
@@ -111,8 +111,10 @@ typedef enum {
 	atom_med_caelement,
 	atom_med_power,
 #endif
+#ifdef ENABLE_CUSTOM
 	atom_custom_list,
 	atom_custom,
+#endif
 } atom_t;
 
 void *_lldpctl_alloc_in_atom(lldpctl_atom_t *, size_t);
@@ -251,6 +253,7 @@ struct _lldpctl_atom_med_power_t {
 };
 #endif
 
+#ifdef ENABLE_CUSTOM
 struct _lldpctl_atom_custom_list_t {
 	lldpctl_atom_t base;
 	struct _lldpctl_atom_port_t *parent;
@@ -262,6 +265,7 @@ struct _lldpctl_atom_custom_t {
 	struct _lldpctl_atom_port_t *parent;
 	struct lldpd_custom *tlv;
 };
+#endif
 
 struct lldpctl_atom_t *_lldpctl_new_atom(lldpctl_conn_t *conn, atom_t type, ...);
 

--- a/src/lib/atoms/config.c
+++ b/src/lib/atoms/config.c
@@ -21,7 +21,6 @@
 #include <arpa/inet.h>
 
 #include "../lldpctl.h"
-#include "../lldpd-structs.h"
 #include "../log.h"
 #include "atom.h"
 #include "helpers.h"

--- a/src/lib/atoms/custom.c
+++ b/src/lib/atoms/custom.c
@@ -26,6 +26,8 @@
 #include "atom.h"
 #include "helpers.h"
 
+#ifdef ENABLE_CUSTOM
+
 #define min(x,y)	( (x > y) ? y : x )
 
 static lldpctl_atom_iter_t*
@@ -183,4 +185,6 @@ static struct atom_builder custom =
 
 ATOM_BUILDER_REGISTER(custom_list, 22);
 ATOM_BUILDER_REGISTER(custom,      23);
+
+#endif /* ENABLE_CUSTOM */
 

--- a/src/lib/atoms/custom.c
+++ b/src/lib/atoms/custom.c
@@ -1,0 +1,186 @@
+/* -*- mode: c; c-file-style: "openbsd" -*- */
+/*
+ * Copyright (c) 2015 Vincent Bernat <vincent@bernat.im>
+ * Copyright (c) 2015 Alexandru Ardelean <ardeleanalex@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <arpa/inet.h>
+
+#include "lldpctl.h"
+#include "../log.h"
+#include "atom.h"
+#include "helpers.h"
+
+#define min(x,y)	( (x > y) ? y : x )
+
+static lldpctl_atom_iter_t*
+_lldpctl_atom_iter_custom_list(lldpctl_atom_t *atom)
+{
+	struct _lldpctl_atom_custom_list_t *custom =
+	    (struct _lldpctl_atom_custom_list_t *)atom;
+	return (lldpctl_atom_iter_t*)TAILQ_FIRST(&custom->parent->port->p_custom_list);
+}
+
+static lldpctl_atom_iter_t*
+_lldpctl_atom_next_custom_list(lldpctl_atom_t *atom, lldpctl_atom_iter_t *iter)
+{
+	return (lldpctl_atom_iter_t*)TAILQ_NEXT((struct lldpd_custom *)iter, next);
+}
+
+static lldpctl_atom_t*
+_lldpctl_atom_value_custom_list(lldpctl_atom_t *atom, lldpctl_atom_iter_t *iter)
+{
+	struct _lldpctl_atom_custom_list_t *custom =
+	    (struct _lldpctl_atom_custom_list_t *)atom;
+	struct lldpd_custom *tlv = (struct lldpd_custom *) iter;
+	return _lldpctl_new_atom(atom->conn, atom_custom, custom->parent, tlv);
+}
+
+static lldpctl_atom_t*
+_lldpctl_atom_create_custom_list(lldpctl_atom_t *atom)
+{
+	struct _lldpctl_atom_custom_list_t *custom =
+	    (struct _lldpctl_atom_custom_list_t *)atom;
+	struct lldpd_custom *tlv;
+
+	tlv = _lldpctl_alloc_in_atom(atom, sizeof(struct lldpd_custom));
+	if (!tlv)
+		return NULL;
+	return _lldpctl_new_atom(atom->conn, atom_custom, custom->parent, tlv);
+}
+
+static int
+_lldpctl_atom_new_custom(lldpctl_atom_t *atom, va_list ap)
+{
+	struct _lldpctl_atom_custom_t *custom =
+	    (struct _lldpctl_atom_custom_t *)atom;
+
+	custom->parent = va_arg(ap, struct _lldpctl_atom_port_t *);
+	custom->tlv    = va_arg(ap, struct lldpd_custom *);
+	lldpctl_atom_inc_ref((lldpctl_atom_t *)custom->parent);
+	return 1;
+}
+
+static void
+_lldpctl_atom_free_custom(lldpctl_atom_t *atom)
+{
+	struct _lldpctl_atom_custom_t *custom =
+	    (struct _lldpctl_atom_custom_t *)atom;
+	lldpctl_atom_dec_ref((lldpctl_atom_t *)custom->parent);
+}
+
+static long int
+_lldpctl_atom_get_int_custom(lldpctl_atom_t *atom, lldpctl_key_t key)
+{
+	struct _lldpctl_atom_custom_t *custom =
+	    (struct _lldpctl_atom_custom_t *)atom;
+
+	switch (key) {
+	case lldpctl_k_custom_tlv_oui_subtype:
+		return custom->tlv->subtype;
+	default:
+		return SET_ERROR(atom->conn, LLDPCTL_ERR_NOT_EXIST);
+	}
+}
+
+static lldpctl_atom_t*
+_lldpctl_atom_set_int_custom(lldpctl_atom_t *atom, lldpctl_key_t key,
+    long int value)
+{
+	struct _lldpctl_atom_custom_t *custom =
+	    (struct _lldpctl_atom_custom_t *)atom;
+
+	switch (key) {
+	case lldpctl_k_custom_tlv_oui_subtype:
+		if (value < 0 || value > 255) goto bad;
+		custom->tlv->subtype = value;
+		return atom;
+	default:
+		SET_ERROR(atom->conn, LLDPCTL_ERR_NOT_EXIST);
+		return NULL;
+	}
+bad:
+	SET_ERROR(atom->conn, LLDPCTL_ERR_BAD_VALUE);
+	return NULL;
+}
+
+static const uint8_t*
+_lldpctl_atom_get_buffer_custom(lldpctl_atom_t *atom, lldpctl_key_t key, size_t *n)
+{
+	struct _lldpctl_atom_custom_t *custom =
+	    (struct _lldpctl_atom_custom_t *)atom;
+
+	switch (key) {
+	case lldpctl_k_custom_tlv_oui:
+		*n = sizeof(custom->tlv->oui);
+		return (const uint8_t *)&custom->tlv->oui;
+	case lldpctl_k_custom_tlv_oui_info_string:
+		*n = custom->tlv->oui_info_len;
+		return (const uint8_t *)&custom->tlv->oui_info;
+	default:
+		SET_ERROR(atom->conn, LLDPCTL_ERR_NOT_EXIST);
+		return NULL;
+	}
+}
+
+static lldpctl_atom_t*
+_lldpctl_atom_set_buffer_custom(lldpctl_atom_t *atom, lldpctl_key_t key,
+    const u_int8_t *buf, size_t n)
+{
+	struct _lldpctl_atom_custom_t *custom =
+	    (struct _lldpctl_atom_custom_t *)atom;
+
+	switch (key) {
+	case lldpctl_k_custom_tlv_oui:
+		memcpy(&custom->tlv->oui, buf, min(n, sizeof(custom->tlv->oui)));
+		return atom;
+	case lldpctl_k_custom_tlv_oui_info_string:
+		if (n == 0 || n > LLDP_TLV_ORG_OUI_INFO_MAXLEN) {
+			SET_ERROR(atom->conn, LLDPCTL_ERR_BAD_VALUE);
+			return NULL;
+		}
+		custom->tlv->oui_info_len = n;
+		memcpy(&custom->tlv->oui_info, buf, n);
+		return atom;
+	default:
+		SET_ERROR(atom->conn, LLDPCTL_ERR_NOT_EXIST);
+		return NULL;
+	}
+}
+
+static struct atom_builder custom_list =
+	{ atom_custom_list, sizeof(struct _lldpctl_atom_any_list_t),
+	  .init  = _lldpctl_atom_new_any_list,
+	  .free  = _lldpctl_atom_free_any_list,
+	  .iter  = _lldpctl_atom_iter_custom_list,
+	  .next  = _lldpctl_atom_next_custom_list,
+	  .value = _lldpctl_atom_value_custom_list, 
+	  .create = _lldpctl_atom_create_custom_list };
+
+static struct atom_builder custom =
+	{ atom_custom, sizeof(struct _lldpctl_atom_custom_t),
+	  .init = _lldpctl_atom_new_custom,
+	  .free = _lldpctl_atom_free_custom,
+	  .get_int = _lldpctl_atom_get_int_custom,
+	  .set_int = _lldpctl_atom_set_int_custom,
+	  .get_buffer = _lldpctl_atom_get_buffer_custom,
+	  .set_buffer = _lldpctl_atom_set_buffer_custom };
+
+ATOM_BUILDER_REGISTER(custom_list, 22);
+ATOM_BUILDER_REGISTER(custom,      23);
+

--- a/src/lib/atoms/custom.c
+++ b/src/lib/atoms/custom.c
@@ -133,7 +133,7 @@ _lldpctl_atom_get_buffer_custom(lldpctl_atom_t *atom, lldpctl_key_t key, size_t 
 		return (const uint8_t *)&custom->tlv->oui;
 	case lldpctl_k_custom_tlv_oui_info_string:
 		*n = custom->tlv->oui_info_len;
-		return (const uint8_t *)&custom->tlv->oui_info;
+		return (const uint8_t *)custom->tlv->oui_info;
 	default:
 		SET_ERROR(atom->conn, LLDPCTL_ERR_NOT_EXIST);
 		return NULL;
@@ -157,7 +157,12 @@ _lldpctl_atom_set_buffer_custom(lldpctl_atom_t *atom, lldpctl_key_t key,
 			return NULL;
 		}
 		custom->tlv->oui_info_len = n;
-		memcpy(&custom->tlv->oui_info, buf, n);
+		if (!(custom->tlv->oui_info = _lldpctl_alloc_in_atom(atom, n))) {
+			custom->tlv->oui_info_len = 0;
+			SET_ERROR(atom->conn, LLDPCTL_ERR_NOMEM);
+			return NULL;
+		}
+		memcpy(custom->tlv->oui_info, buf, n);
 		return atom;
 	default:
 		SET_ERROR(atom->conn, LLDPCTL_ERR_NOT_EXIST);

--- a/src/lib/atoms/dot1.c
+++ b/src/lib/atoms/dot1.c
@@ -21,7 +21,6 @@
 #include <arpa/inet.h>
 
 #include "lldpctl.h"
-#include "../lldpd-structs.h"
 #include "../log.h"
 #include "atom.h"
 #include "helpers.h"

--- a/src/lib/atoms/dot3.c
+++ b/src/lib/atoms/dot3.c
@@ -21,7 +21,6 @@
 #include <arpa/inet.h>
 
 #include "lldpctl.h"
-#include "../lldpd-structs.h"
 #include "../log.h"
 #include "atom.h"
 #include "helpers.h"

--- a/src/lib/atoms/interface.c
+++ b/src/lib/atoms/interface.c
@@ -21,7 +21,6 @@
 #include <arpa/inet.h>
 
 #include "lldpctl.h"
-#include "../lldpd-structs.h"
 #include "../log.h"
 #include "atom.h"
 #include "helpers.h"

--- a/src/lib/atoms/med.c
+++ b/src/lib/atoms/med.c
@@ -21,7 +21,6 @@
 #include <arpa/inet.h>
 
 #include "lldpctl.h"
-#include "../lldpd-structs.h"
 #include "../log.h"
 #include "atom.h"
 #include "helpers.h"

--- a/src/lib/atoms/mgmt.c
+++ b/src/lib/atoms/mgmt.c
@@ -21,7 +21,6 @@
 #include <arpa/inet.h>
 
 #include "lldpctl.h"
-#include "../lldpd-structs.h"
 #include "../log.h"
 #include "atom.h"
 #include "helpers.h"

--- a/src/lib/atoms/port.c
+++ b/src/lib/atoms/port.c
@@ -21,7 +21,6 @@
 #include <arpa/inet.h>
 
 #include "lldpctl.h"
-#include "../lldpd-structs.h"
 #include "../log.h"
 #include "atom.h"
 #include "helpers.h"

--- a/src/lib/atoms/port.c
+++ b/src/lib/atoms/port.c
@@ -273,6 +273,8 @@ _lldpctl_atom_get_atom_port(lldpctl_atom_t *atom, lldpctl_key_t key)
 	case lldpctl_k_port_med_power:
 		return _lldpctl_new_atom(atom->conn, atom_med_power, p);
 #endif
+	case lldpctl_k_custom_tlvs:
+		return _lldpctl_new_atom(atom->conn, atom_custom_list, p);
 	default:
 		SET_ERROR(atom->conn, LLDPCTL_ERR_NOT_EXIST);
 		return NULL;
@@ -297,6 +299,7 @@ _lldpctl_atom_set_atom_port(lldpctl_atom_t *atom, lldpctl_key_t key, lldpctl_ato
 	struct _lldpctl_atom_med_policy_t *mpol;
 	struct _lldpctl_atom_med_location_t *mloc;
 #endif
+	struct _lldpctl_atom_custom_t    *custom;
 
 	/* Local port only */
 	if (hardware == NULL) {
@@ -349,6 +352,17 @@ _lldpctl_atom_set_atom_port(lldpctl_atom_t *atom, lldpctl_key_t key, lldpctl_ato
 		set.med_location = mloc->location;
 		break;
 #endif
+	case lldpctl_k_custom_tlvs_clear:
+		set.custom_list_clear = 1;
+		break;
+	case lldpctl_k_custom_tlv:
+		if (value->type != atom_custom) {
+			SET_ERROR(atom->conn, LLDPCTL_ERR_INCORRECT_ATOM_TYPE);
+			return NULL;
+		}
+		custom = (struct _lldpctl_atom_custom_t *)value;
+		set.custom = custom->tlv;
+		break;
 	default:
 		SET_ERROR(atom->conn, LLDPCTL_ERR_NOT_EXIST);
 		return NULL;

--- a/src/lib/atoms/port.c
+++ b/src/lib/atoms/port.c
@@ -273,8 +273,10 @@ _lldpctl_atom_get_atom_port(lldpctl_atom_t *atom, lldpctl_key_t key)
 	case lldpctl_k_port_med_power:
 		return _lldpctl_new_atom(atom->conn, atom_med_power, p);
 #endif
+#ifdef ENABLE_CUSTOM
 	case lldpctl_k_custom_tlvs:
 		return _lldpctl_new_atom(atom->conn, atom_custom_list, p);
+#endif
 	default:
 		SET_ERROR(atom->conn, LLDPCTL_ERR_NOT_EXIST);
 		return NULL;
@@ -299,7 +301,9 @@ _lldpctl_atom_set_atom_port(lldpctl_atom_t *atom, lldpctl_key_t key, lldpctl_ato
 	struct _lldpctl_atom_med_policy_t *mpol;
 	struct _lldpctl_atom_med_location_t *mloc;
 #endif
+#ifdef ENABLE_CUSTOM
 	struct _lldpctl_atom_custom_t    *custom;
+#endif
 
 	/* Local port only */
 	if (hardware == NULL) {
@@ -352,6 +356,7 @@ _lldpctl_atom_set_atom_port(lldpctl_atom_t *atom, lldpctl_key_t key, lldpctl_ato
 		set.med_location = mloc->location;
 		break;
 #endif
+#ifdef ENABLE_CUSTOM
 	case lldpctl_k_custom_tlvs_clear:
 		set.custom_list_clear = 1;
 		break;
@@ -363,6 +368,7 @@ _lldpctl_atom_set_atom_port(lldpctl_atom_t *atom, lldpctl_key_t key, lldpctl_ato
 		custom = (struct _lldpctl_atom_custom_t *)value;
 		set.custom = custom->tlv;
 		break;
+#endif
 	default:
 		SET_ERROR(atom->conn, LLDPCTL_ERR_NOT_EXIST);
 		return NULL;

--- a/src/lib/connection.c
+++ b/src/lib/connection.c
@@ -26,7 +26,6 @@
 #include "../compat/compat.h"
 #include "../ctl.h"
 #include "../log.h"
-#include "../lldpd-structs.h"
 
 const char*
 lldpctl_get_default_transport(void)

--- a/src/lib/helpers.c
+++ b/src/lib/helpers.c
@@ -21,7 +21,6 @@
 #include <arpa/inet.h>
 
 #include "lldpctl.h"
-#include "../lldpd-structs.h"
 #include "../log.h"
 #include "atom.h"
 #include "helpers.h"

--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -740,6 +740,14 @@ typedef enum {
 	lldpctl_k_config_tx_hold, /**< `(I,WO)` Transmit hold interval. */
 	lldpctl_k_config_bond_slave_src_mac_type, /**< `(I,WO)` bond slave src mac type. */
 	lldpctl_k_config_lldp_portid_type, /**< `(I,WO)` LLDP PortID TLV Subtype */
+
+	lldpctl_k_custom_tlvs = 5000,		/**< `(AL)` custom TLVs */
+	lldpctl_k_custom_tlvs_clear,		/** `(I,WO)` clear list of custom TLVs */
+	lldpctl_k_custom_tlv,			/** `(AL,WO)` custom TLV **/
+	lldpctl_k_custom_tlv_oui,		/**< `(I,WO)` custom TLV Organizationally Unique Identifier. Default is 0 (3 bytes) */
+	lldpctl_k_custom_tlv_oui_subtype,	/**< `(I,WO)` custom TLV subtype. Default is 0 (1 byte) */
+	lldpctl_k_custom_tlv_oui_info_string,	/**< `(I,WO)` custom TLV Organizationally Unique Identifier Information String (up to 507 bytes) */
+
 } lldpctl_key_t;
 
 /**

--- a/src/lldp-const.h
+++ b/src/lldp-const.h
@@ -23,6 +23,8 @@
  * constants that are useful in the context of lldpd and its clients.
  */
 
+#define LLDP_TLV_ORG			127
+
 /* Chassis ID subtype */
 #define LLDP_CHASSISID_SUBTYPE_CHASSIS	1
 #define LLDP_CHASSISID_SUBTYPE_IFALIAS	2

--- a/src/lldp-const.h
+++ b/src/lldp-const.h
@@ -24,6 +24,8 @@
  */
 
 #define LLDP_TLV_ORG			127
+#define LLDP_TLV_ORG_OUI_LEN		3
+#define LLDP_TLV_ORG_OUI_INFO_MAXLEN	507
 
 /* Chassis ID subtype */
 #define LLDP_CHASSISID_SUBTYPE_CHASSIS	1

--- a/src/lldpd-structs.c
+++ b/src/lldpd-structs.c
@@ -112,6 +112,7 @@ lldpd_custom_list_cleanup(struct lldpd_port *port)
 	    custom != NULL;
 	    custom = custom_next) {
 		custom_next = TAILQ_NEXT(custom, next);
+		free(custom->oui_info);
 		free(custom);
 	}
 	TAILQ_INIT(&port->p_custom_list);

--- a/src/lldpd-structs.c
+++ b/src/lldpd-structs.c
@@ -103,6 +103,7 @@ lldpd_pi_cleanup(struct lldpd_port *port)
 }
 #endif
 
+#ifdef ENABLE_CUSTOM
 void 
 lldpd_custom_list_cleanup(struct lldpd_port *port)
 {
@@ -115,6 +116,7 @@ lldpd_custom_list_cleanup(struct lldpd_port *port)
 	}
 	TAILQ_INIT(&port->p_custom_list);
 }
+#endif
 
 /* Cleanup a remote port. The before last argument, `expire` is a function that
  * should be called when a remote port is removed. If the last argument is 1,
@@ -184,7 +186,9 @@ lldpd_port_cleanup(struct lldpd_port *port, int all)
 			port->p_chassis->c_refcount--;
 			port->p_chassis = NULL;
 		}
+#ifdef ENABLE_CUSTOM
 		lldpd_custom_list_cleanup(port);
+#endif
 	}
 }
 

--- a/src/lldpd-structs.c
+++ b/src/lldpd-structs.c
@@ -103,6 +103,19 @@ lldpd_pi_cleanup(struct lldpd_port *port)
 }
 #endif
 
+void 
+lldpd_custom_list_cleanup(struct lldpd_port *port)
+{
+	struct lldpd_custom *custom, *custom_next;
+	for (custom = TAILQ_FIRST(&port->p_custom_list);
+	    custom != NULL;
+	    custom = custom_next) {
+		custom_next = TAILQ_NEXT(custom, next);
+		free(custom);
+	}
+	TAILQ_INIT(&port->p_custom_list);
+}
+
 /* Cleanup a remote port. The before last argument, `expire` is a function that
  * should be called when a remote port is removed. If the last argument is 1,
  * all remote ports are removed.
@@ -171,6 +184,7 @@ lldpd_port_cleanup(struct lldpd_port *port, int all)
 			port->p_chassis->c_refcount--;
 			port->p_chassis = NULL;
 		}
+		lldpd_custom_list_cleanup(port);
 	}
 }
 

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -214,6 +214,22 @@ MARSHAL_STR(lldpd_chassis, c_med_asset)
 #endif
 MARSHAL_END(lldpd_chassis);
 
+/* Custom TLV struct as defined on page 35 of IEEE 802.1AB-2005 */
+struct lldpd_custom {
+	TAILQ_ENTRY(lldpd_custom)	next;	/* Pointer to next custom TLV */
+
+	/* Organizationally Unique Identifier */
+	u_int8_t		oui[LLDP_TLV_ORG_OUI_LEN];
+	/* Organizationally Defined Subtype */
+	u_int8_t		subtype;
+	/* Organizationally Defined Information String; for now/simplicity static array */
+	u_int8_t		oui_info[LLDP_TLV_ORG_OUI_INFO_MAXLEN];
+	/* Organizationally Defined Information String length */
+	int			oui_info_len;
+};
+MARSHAL_BEGIN(lldpd_custom)
+MARSHAL_TQE(lldpd_custom, next)
+MARSHAL_END(lldpd_custom);
 
 struct lldpd_port {
 	TAILQ_ENTRY(lldpd_port)	 p_entries;
@@ -253,6 +269,7 @@ struct lldpd_port {
 	TAILQ_HEAD(, lldpd_ppvid) p_ppvids;
 	TAILQ_HEAD(, lldpd_pi)	  p_pids;
 #endif
+	TAILQ_HEAD(, lldpd_custom) p_custom_list;
 };
 MARSHAL_BEGIN(lldpd_port)
 MARSHAL_TQE(lldpd_port, p_entries)
@@ -270,6 +287,7 @@ MARSHAL_SUBTQ(lldpd_port, lldpd_vlan, p_vlans)
 MARSHAL_SUBTQ(lldpd_port, lldpd_ppvid, p_ppvids)
 MARSHAL_SUBTQ(lldpd_port, lldpd_pi, p_pids)
 #endif
+MARSHAL_SUBTQ(lldpd_port, lldpd_custom, p_custom_list)
 MARSHAL_END(lldpd_port);
 
 /* Used to modify some port related settings */
@@ -483,5 +501,6 @@ void	 lldpd_ppvid_cleanup(struct lldpd_port *);
 void	 lldpd_vlan_cleanup(struct lldpd_port *);
 void	 lldpd_pi_cleanup(struct lldpd_port *);
 #endif
+void     lldpd_custom_list_cleanup(struct lldpd_port *);
 
 #endif

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -214,6 +214,7 @@ MARSHAL_STR(lldpd_chassis, c_med_asset)
 #endif
 MARSHAL_END(lldpd_chassis);
 
+#ifdef ENABLE_CUSTOM
 /* Custom TLV struct as defined on page 35 of IEEE 802.1AB-2005 */
 struct lldpd_custom {
 	TAILQ_ENTRY(lldpd_custom)	next;	/* Pointer to next custom TLV */
@@ -230,6 +231,7 @@ struct lldpd_custom {
 MARSHAL_BEGIN(lldpd_custom)
 MARSHAL_TQE(lldpd_custom, next)
 MARSHAL_END(lldpd_custom);
+#endif
 
 struct lldpd_port {
 	TAILQ_ENTRY(lldpd_port)	 p_entries;
@@ -269,7 +271,9 @@ struct lldpd_port {
 	TAILQ_HEAD(, lldpd_ppvid) p_ppvids;
 	TAILQ_HEAD(, lldpd_pi)	  p_pids;
 #endif
+#ifdef ENABLE_CUSTOM
 	TAILQ_HEAD(, lldpd_custom) p_custom_list;
+#endif
 };
 MARSHAL_BEGIN(lldpd_port)
 MARSHAL_TQE(lldpd_port, p_entries)
@@ -287,7 +291,9 @@ MARSHAL_SUBTQ(lldpd_port, lldpd_vlan, p_vlans)
 MARSHAL_SUBTQ(lldpd_port, lldpd_ppvid, p_ppvids)
 MARSHAL_SUBTQ(lldpd_port, lldpd_pi, p_pids)
 #endif
+#ifdef ENABLE_CUSTOM
 MARSHAL_SUBTQ(lldpd_port, lldpd_custom, p_custom_list)
+#endif
 MARSHAL_END(lldpd_port);
 
 /* Used to modify some port related settings */
@@ -303,8 +309,10 @@ struct lldpd_port_set {
 #ifdef ENABLE_DOT3
 	struct lldpd_dot3_power *dot3_power;
 #endif
+#ifdef ENABLE_CUSTOM
 	struct lldpd_custom     *custom;
 	int custom_list_clear;
+#endif
 };
 MARSHAL_BEGIN(lldpd_port_set)
 MARSHAL_STR(lldpd_port_set, ifname)
@@ -318,7 +326,9 @@ MARSHAL_POINTER(lldpd_port_set, lldpd_med_power,  med_power)
 #ifdef ENABLE_DOT3
 MARSHAL_POINTER(lldpd_port_set, lldpd_dot3_power, dot3_power)
 #endif
+#ifdef ENABLE_CUSTOM
 MARSHAL_POINTER(lldpd_port_set, lldpd_custom,     custom)
+#endif
 MARSHAL_END(lldpd_port_set);
 
 /* Smart mode / Hide mode */
@@ -504,6 +514,8 @@ void	 lldpd_ppvid_cleanup(struct lldpd_port *);
 void	 lldpd_vlan_cleanup(struct lldpd_port *);
 void	 lldpd_pi_cleanup(struct lldpd_port *);
 #endif
+#ifdef ENABLE_CUSTOM
 void     lldpd_custom_list_cleanup(struct lldpd_port *);
+#endif
 
 #endif

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -303,6 +303,8 @@ struct lldpd_port_set {
 #ifdef ENABLE_DOT3
 	struct lldpd_dot3_power *dot3_power;
 #endif
+	struct lldpd_custom     *custom;
+	int custom_list_clear;
 };
 MARSHAL_BEGIN(lldpd_port_set)
 MARSHAL_STR(lldpd_port_set, ifname)
@@ -316,6 +318,7 @@ MARSHAL_POINTER(lldpd_port_set, lldpd_med_power,  med_power)
 #ifdef ENABLE_DOT3
 MARSHAL_POINTER(lldpd_port_set, lldpd_dot3_power, dot3_power)
 #endif
+MARSHAL_POINTER(lldpd_port_set, lldpd_custom,     custom)
 MARSHAL_END(lldpd_port_set);
 
 /* Smart mode / Hide mode */

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -224,12 +224,13 @@ struct lldpd_custom {
 	/* Organizationally Defined Subtype */
 	u_int8_t		subtype;
 	/* Organizationally Defined Information String; for now/simplicity static array */
-	u_int8_t		oui_info[LLDP_TLV_ORG_OUI_INFO_MAXLEN];
+	u_int8_t		*oui_info;
 	/* Organizationally Defined Information String length */
 	int			oui_info_len;
 };
 MARSHAL_BEGIN(lldpd_custom)
 MARSHAL_TQE(lldpd_custom, next)
+MARSHAL_FSTR(lldpd_custom, oui_info, oui_info_len)
 MARSHAL_END(lldpd_custom);
 #endif
 


### PR DESCRIPTION
Added commands for `lldpcli`:
- `configure lldp custom-tlv oui 88,99,AA, subtype BB <oui-info CC,DD,EE...>` - to add a single custom TLV
- `unconfigure lldp custom-tlvs` - to remove all custom TLVs set

Add support for lldpctl to display custom TLVs.
Something like below [some info was redacted out].
```
Interface:    lan2, via: LLDP, RID: 3, Time: 0 day, 00:00:03
  Chassis:     
    ChassisID:    mac 74:D4:35:0A:C7:F3
    SysName:      192.168.0.23
    SysDescr:     OpenWRT Chaos Chalmer
  Port:        
    PortID:       local BLUE_LAN
    PortDescr:    eth0
  CustomTLVs:  
    TLV:          OUI: 11,22,33, SubType: 44, Len: 0
    TLV:          OUI: 11,22,33, SubType: 44, Len: 0
    TLV:          OUI: 11,22,33, SubType: 44, Len: 4 22,33,44,55
    TLV:          OUI: 11,22,33, SubType: 44, Len: 3 77,88,99
```

No hurry to review this.
Will also wait for build errors that may be caught by Travis-CI,

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>