### PR TITLE
lldpd: consider interfaces which are not running also for RTM_DELLINK event

### DIFF
--- a/src/daemon/netlink.c
+++ b/src/daemon/netlink.c
@@ -131,11 +131,6 @@ netlink_parse_link(struct nlmsghdr *msg,
     ifi = NLMSG_DATA(msg);
     len = msg->nlmsg_len - NLMSG_LENGTH(sizeof(struct ifinfomsg));
 
-    if (!((ifi->ifi_flags & IFF_UP) && (ifi->ifi_flags & IFF_RUNNING))) {
-        log_debug("netlink", "skip down interface at index %d",
-          ifi->ifi_index);
-        return -1;
-    }
     if (ifi->ifi_type != ARPHRD_ETHER) {
         log_debug("netlink", "skip non Ethernet interface at index %d",
           ifi->ifi_index);
@@ -303,6 +298,7 @@ netlink_recv(int s,
                 log_debug("netlink", "received end of dump message");
                 end = 1;
                 break;
+            case RTM_DELLINK:
             case RTM_NEWLINK:
                 if (!ifs) break;
                 log_debug("netlink", "received link information");


### PR DESCRIPTION
That way hardware->h_flags get updated, and the hardware object
is not free'd.
When the interface comes back online (with a link), the iface->flags
(and consequently hardware->h_flags) get updated.

This is a bit easier than trying to do other more complex logic,
for keeping duplicate (persistent) information.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>