### PR TITLE
Don't use container-based Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c
 os: linux
 compiler: gcc
+sudo: require
 install:
   - ./.travis/install.sh
 script:


### PR DESCRIPTION
When i have fork the project and try to build on Travis,

Travis try to use container based (and no old travis infra) and the code don't build 

(May be a another solution, it is to try to use new container infra...)