### PR TITLE
redhat: fix minor issues in .spec file

### DIFF
--- a/redhat/lldpd.spec
+++ b/redhat/lldpd.spec
@@ -81,7 +81,7 @@ protocol. It also handles LLDP-MED extension.
 %package devel
 Summary:  Implementation of IEEE 802.1ab - Tools and header files for developers
 Group:    Development/Libraries/C
-BuildRequires: pkg-config
+BuildRequires: pkgconfig
 Requires: lldpd = %{version}-%{release}
 
 %description devel


### PR DESCRIPTION
- fix BuildRequires package name (pkgconfig instead of pkg-config)
- fix installation source for bash_completion file