### PR TITLE
lldpcli: rename "unconfigure lldp custom-tlvs" to "unconfigure lldp custom-tlv"

### DIFF
--- a/src/client/conf-lldp.c
+++ b/src/client/conf-lldp.c
@@ -454,7 +454,7 @@ register_commands_configure_lldp(struct cmd_node *configure,
 	register_commands_configure_lldp_custom_tlvs(configure_lldp);
 	commands_new(
 		commands_new(unconfigure_lldp,
-			"custom-tlvs",
+			"custom-tlv",
 			"Clear all (previously set) custom TLVs",
 			NULL, NULL, NULL),
 		NEWLINE, "Clear all (previously set) custom TLVs",


### PR DESCRIPTION
There was a bit of confusion regarding this command.
It's documented as 'unconfigure lldp custom-tlv', when in fact it's 'unconfigure lldp custom-tlvs' (plural).

That's also my fault, since I did not update much (or take care about) documentation.
It seems simpler to rename the command as is in the doc than change the doc.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>