### PR TITLE
Make the default platform name really the kernel name

### DIFF
--- a/src/daemon/protocols/cdp.c
+++ b/src/daemon/protocols/cdp.c
@@ -21,6 +21,8 @@
 
 #if defined (ENABLE_CDP) || defined (ENABLE_FDP)
 
+#include <sys/utsname.h>
+
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>
@@ -31,7 +33,8 @@ static int
 cdp_send(struct lldpd *global,
 	 struct lldpd_hardware *hardware, int version)
 {
-	const char *platform = "Linux";
+	const char *platform;
+	struct utsname utsname;
 	struct lldpd_chassis *chassis;
 	struct lldpd_mgmt *mgmt;
 	struct lldpd_port *port;
@@ -198,7 +201,13 @@ cdp_send(struct lldpd *global,
 		goto toobig;
 
 	/* Platform */
-	if (global && global->g_config.c_platform) platform = global->g_config.c_platform;
+	if (global && global->g_config.c_platform)
+		platform = global->g_config.c_platform;
+	else {
+		uname(&utsname);
+		platform = utsname.sysname;
+	}
+
 	if (!(
 	      POKE_START_CDP_TLV(CDP_TLV_PLATFORM) &&
 	      POKE_BYTES(platform, strlen(platform)) &&


### PR DESCRIPTION
Instead of hardcoding 'Linux" directly query the kernel name of the user
is not overwriting it.