### PR TITLE
build: check runtime support of constructor/destructor

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,17 +88,7 @@ AX_CFLAGS_GCC_OPTION([-Wno-missing-field-initializers], [LLDP_CFLAGS])
 AX_CFLAGS_GCC_OPTION([-Wno-sign-compare], [LLDP_CFLAGS]) dnl Should be fixed later
 AX_LDFLAGS_OPTION([-Wl,-z,relro], [LLDP_LDFLAGS])
 AX_LDFLAGS_OPTION([-Wl,-z,now], [LLDP_LDFLAGS])
-
-# Also, we require support of constructor/destructor
-AX_GCC_FUNC_ATTRIBUTE(constructor)
-if test x"$ac_cv_have_func_attribute_constructor" = x"no"; then
-  AC_MSG_FAILURE([*** GCC constructor function attribute mandatory])
-fi
-AX_GCC_FUNC_ATTRIBUTE(constructor_priority)
-AX_GCC_FUNC_ATTRIBUTE(destructor)
-if test x"$ac_cv_have_func_attribute_destructor" = x"no"; then
-  AC_MSG_FAILURE([*** GCC destructor function attribute mandatory])
-fi
+lldp_CHECK_CTORS
 
 # Hardening
 AC_ARG_ENABLE([hardening],

--- a/m4/ctors.m4
+++ b/m4/ctors.m4
@@ -1,0 +1,48 @@
+#
+# lldp_CHECK_CTORS
+#
+AC_DEFUN([lldp_CHECK_CTORS], [
+
+  # Compiler support
+  AX_GCC_FUNC_ATTRIBUTE(constructor)
+  if test x"$ac_cv_have_func_attribute_constructor" = x"no"; then
+    AC_MSG_FAILURE([*** GCC constructor function attribute mandatory])
+  fi
+  AX_GCC_FUNC_ATTRIBUTE(constructor_priority)
+  AX_GCC_FUNC_ATTRIBUTE(destructor)
+  if test x"$ac_cv_have_func_attribute_destructor" = x"no"; then
+    AC_MSG_FAILURE([*** GCC destructor function attribute mandatory])
+  fi
+
+  # Runtime support (libc)
+  AC_CACHE_CHECK([constructor/destructor runtime support], lldp_cv_ctor_runtime, [
+    dnl We need to observe some sideeffect. When
+    dnl constructor/destructors are running, we may not have a working
+    dnl standard output.
+    true > conftest.1
+    true > conftest.2
+    AC_RUN_IFELSE([AC_LANG_PROGRAM([
+      @%:@include <unistd.h>
+      void ctor1(void) __attribute__((constructor));
+      void ctor1() { unlink("conftest.1"); }
+      void ctor2(void) __attribute__((destructor));
+      void ctor2() { unlink("conftest.2"); }], [])
+    ], [
+      if test -r conftest.1 -o -r conftest.2; then
+        lldp_cv_ctor_runtime=no
+      else
+        lldp_cv_ctor_runtime=yes
+      fi
+    ], [
+      dnl Unable to build the check
+      lldp_cv_ctor_runtime=no
+    ], [
+      dnl Cross compilation
+      lldp_cv_ctor_runtime=yes
+    ])
+  ])
+
+  if test x"$lldp_cv_ctor_runtime" = x"no"; then
+    AC_MSG_FAILURE([*** Constructor/destructor runtime support is missing])
+  fi
+])


### PR DESCRIPTION
With some libc, we may have a compile-time support (through GCC), but
not a runtime support. For example, with uclibc, support for
constructors/destructors is optional. They can be enabled with
`CFLAGS=--uclibc-ctors` on some versions. On some others, they need to
be builtin by compiling uclibc with UCLIBC_CTOR_DTOR.

Unfortunately, cannot be tested when cross-compilation is in effect.

This is a PR because it needs some additional tests.