### PR TITLE
Make build of unit tests optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -200,9 +200,6 @@ m4_popdef([AC_LANG_CALL(C)])
 
 AC_CACHE_SAVE
 
-## Unit tests wich check
-PKG_CHECK_MODULES([CHECK], [check >= 0.9.4], [have_check=yes], [have_check=no])
-
 # Third-party libraries
 lldp_CHECK_LIBEVENT
 
@@ -216,6 +213,18 @@ m4_ifdef([PKG_INSTALLDIR], [PKG_INSTALLDIR],
 
 #######################
 ### Options
+
+## Unit tests with check
+AC_ARG_WITH([unittests],
+  AS_HELP_STRING(
+    [--with-unittests],
+    [Build unit tests @<:@default=yes@:>@]),
+    [],
+    [with_unittests=yes])
+have_check=no
+if test x"$with_unittests" = x"yes"; then
+   PKG_CHECK_MODULES([CHECK], [check >= 0.9.4], [have_check=yes], [have_check=no])
+fi
 
 # Readline
 AC_ARG_WITH([readline],


### PR DESCRIPTION
This commit will adds a `configure` option, `{with, without}-unittests` (default: yes),
which can be used to disable building the unit tests.

In my case, rebuilding `lldpd` often, disabling the build of unit tests shorten the building process a little bit.
I also identified a problem when cross-compiling, if `check` could be found on the host system but not for the target system, the compilation failed due to that `configure` found `check` (on host system) and then tried to use it when building the target system. I might have done something wrong in my setup, but disabling the unit test solved my problem.
