### PR TITLE
[RFC] lib/connection: simplify lldpctl_recv() function

### DIFF
--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -140,13 +140,11 @@ typedef ssize_t (*lldpctl_recv_callback)(lldpctl_conn_t *conn,
  * available from lldpd (expected or unexpected).
  *
  * @param  conn      Handle to the connection to lldpd.
- * @param  data      Data received from lldpd.
- * @param  length    Length of data received.
  * @return The number of bytes available or a negative integer if an error has
  *         occurred. 0 is not an error. It usually means that a notification has
  *         been processed.
  */
-ssize_t lldpctl_recv(lldpctl_conn_t *conn, const uint8_t *data, size_t length);
+ssize_t lldpctl_recv(lldpctl_conn_t *conn);
 
 /**
  * Function invoked when there is an opportunity to send data to lldpd.


### PR DESCRIPTION
The final aim is to have async IO.

We're using uloop() (from OpenWrt) which is a wrapper on top
of epoll().
uloop() is a main-loop type of mechanism, which means FDs need
to be assigned to it, and then if the epoll() has some events,
it would trigger the handlers for the registered (with epoll) FDs.

With the current way liblldpctl looks like, async IO is not too
perfect.

But, regarding lldpctl_recv() it looks like it could call the
conn->recv() pointer, since it's mandatory anyway to pass it
in order to get a async-IO-ish mechanism.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>