### PR TITLE
client: add an option to use pre-0.9.2 json-c format

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+lldpd (0.9.6)
+  * Change:
+    + Add a compile-time option to restore pre-0.9.2 JSON format (when
+      using json-c). Use `--enable-json0` to enable this option.
+
 lldpd (0.9.5)
   * Change:
     + More Ethernet media supported. However, RFC4836 is quite

--- a/configure.ac
+++ b/configure.ac
@@ -291,6 +291,7 @@ else
    lldp_CHECK_JANSSON
    lldp_CHECK_JSONC
 fi
+lldp_ARG_ENABLE([json0], [use of pre-0.9.2 JSON/json-c format], [no])
 
 # Seccomp
 AC_ARG_WITH([seccomp],

--- a/src/client/jansson_writer.c
+++ b/src/client/jansson_writer.c
@@ -96,8 +96,9 @@ jansson_data(struct writer *w, const char *data)
 static json_t*
 jansson_cleanup(json_t *el)
 {
-	json_t *new;
 	if (el == NULL) return NULL;
+#ifndef ENABLE_JSON0
+	json_t *new;
 	if (json_is_array(el) && json_array_size(el) == 1) {
 		new = json_array_get(el, 0);
 		return jansson_cleanup(new);
@@ -144,6 +145,7 @@ jansson_cleanup(json_t *el)
 		}
 		return new;
 	}
+#endif
 	json_incref(el);
 	return el;
 }

--- a/src/client/jsonc_writer.c
+++ b/src/client/jsonc_writer.c
@@ -95,8 +95,9 @@ jsonc_data(struct writer *w, const char *data)
 static json_object*
 jsonc_cleanup(json_object *el)
 {
-	json_object *new;
 	if (el == NULL) return NULL;
+#ifndef ENABLE_JSON0
+	json_object *new;
 	if (json_object_get_type(el) == json_type_array) {
 		size_t len = json_object_array_length(el);
 		if (len == 1) {
@@ -140,6 +141,7 @@ jsonc_cleanup(json_object *el)
 		}
 		return new;
 	}
+#endif
 	json_object_get(el);
 	return el;
 }


### PR DESCRIPTION
The format has been changed in c8b8b858bbba to match the JSON format
used when compiled with Jansson. Some users may want to revert this
change. Add `--enable-json0` option for that.