### PR TITLE
seccomp: add mprotect to seccomp whitelist

### DIFF
--- a/src/daemon/priv-seccomp.c
+++ b/src/daemon/priv-seccomp.c
@@ -166,6 +166,7 @@ priv_seccomp_init(int remote, int child)
 	    (rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(poll), 0)) < 0 ||
 	    (rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(recvmsg), 0)) < 0 ||
 	    (rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(readv), 0)) < 0 ||
+	    (rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(mprotect), 0)) < 0 ||
 	    /* The following are for resolving addresses */
 	    (rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(mmap), 0)) < 0 ||
 	    (rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(munmap), 0)) < 0 ||


### PR DESCRIPTION
https://bugs.gentoo.org/600210

It seems that there are some situation where lldpd requires mprotect to run, and it is not in the seccomp whitelist.