### PR TITLE
Auto-adapt Netlink socket size

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@ lldpd (0.9.6)
     + Support for newer ethtool interface on Linux
       (ETHTOOL_GLINKSETTINGS) and additional speed settings.
     + Current MAU type is displayed even when autoneg is off.
+    + Increase netlink receive buffer by default. Can be changed at
+      compile-time through ./configure.
   * Fix:
     + Correctly parse LLDP-MED civic address when the length of the
       TLV exceeds the length of the address.

--- a/configure.ac
+++ b/configure.ac
@@ -348,8 +348,8 @@ lldp_ARG_WITH([lldpd-ctl-socket], [Path to socket for communication with lldpd],
 lldp_ARG_WITH([lldpd-pid-file], [Path to lldpd PID file], [${runstatedir}/lldpd.pid])
 
 # Netlink
-lldp_ARG_WITH_UNQUOTED([netlink-max-receive-bufsize], [Netlink maximum receive buffer size], [4*1024*1024])
-lldp_ARG_WITH_UNQUOTED([netlink-receive-bufsize], [Netlink initial receive buffer size], [256*1024])
+lldp_ARG_WITH_UNQUOTED([netlink-max-receive-bufsize], [Netlink maximum receive buffer size], [1024*1024])
+lldp_ARG_WITH_UNQUOTED([netlink-receive-bufsize], [Netlink initial receive buffer size], [0])
 lldp_ARG_WITH_UNQUOTED([netlink-send-bufsize], [Netlink send buffer size], [0])
 
 # CDP/FDP/EDP/SONMP

--- a/configure.ac
+++ b/configure.ac
@@ -348,7 +348,8 @@ lldp_ARG_WITH([lldpd-ctl-socket], [Path to socket for communication with lldpd],
 lldp_ARG_WITH([lldpd-pid-file], [Path to lldpd PID file], [${runstatedir}/lldpd.pid])
 
 # Netlink
-lldp_ARG_WITH_UNQUOTED([netlink-receive-bufsize], [Netlink receive buffer size], [256*1024])
+lldp_ARG_WITH_UNQUOTED([netlink-max-receive-bufsize], [Netlink maximum receive buffer size], [4*1024*1024])
+lldp_ARG_WITH_UNQUOTED([netlink-receive-bufsize], [Netlink initial receive buffer size], [256*1024])
 lldp_ARG_WITH_UNQUOTED([netlink-send-bufsize], [Netlink send buffer size], [0])
 
 # CDP/FDP/EDP/SONMP

--- a/configure.ac
+++ b/configure.ac
@@ -347,6 +347,10 @@ lldp_ARG_WITH([privsep-chroot], [Which directory to use to chroot lldpd], [${run
 lldp_ARG_WITH([lldpd-ctl-socket], [Path to socket for communication with lldpd], [${runstatedir}/lldpd.socket])
 lldp_ARG_WITH([lldpd-pid-file], [Path to lldpd PID file], [${runstatedir}/lldpd.pid])
 
+# Netlink
+lldp_ARG_WITH_UNQUOTED([netlink-receive-bufsize], [Netlink receive buffer size], [256*1024])
+lldp_ARG_WITH_UNQUOTED([netlink-send-bufsize], [Netlink send buffer size], [0])
+
 # CDP/FDP/EDP/SONMP
 lldp_ARG_ENABLE([cdp], [Cisco Discovery Protocol], [yes])
 lldp_ARG_ENABLE([fdp], [Foundry Discovery Protocol], [yes])

--- a/m4/args.m4
+++ b/m4/args.m4
@@ -36,6 +36,19 @@ AC_DEFUN([lldp_AC_EXPAND], [
   exec_prefix=$exec_prefix_save
 ])
 
+dnl lldp_ARG_WITH_UNQUOTED(name, help1, default)
+
+AC_DEFUN([lldp_ARG_WITH_UNQUOTED],[
+  AC_ARG_WITH([$1],
+	AS_HELP_STRING([--with-$1],
+		[$2 @<:@default=$3@:>@]),[
+        AC_DEFINE_UNQUOTED(AS_TR_CPP([$1]), [$withval], [$2])
+        AC_SUBST(AS_TR_CPP([$1]), [$withval])],[
+	AC_DEFINE_UNQUOTED(AS_TR_CPP([$1]), [$3], [$2])
+        AC_SUBST(AS_TR_CPP([$1]), [$3])
+        eval with_[]m4_translit([$1], [-+.], [___])=$3
+])])
+
 dnl lldp_ARG_WITH(name, help1, default)
 
 AC_DEFUN([lldp_ARG_WITH],[

--- a/src/daemon/netlink.c
+++ b/src/daemon/netlink.c
@@ -67,7 +67,7 @@ netlink_socket_set_buffer_sizes(int s, int sndbuf, int rcvbuf)
 		if (getsockopt(s, SOL_SOCKET, SO_SNDBUF, &got, &size) < 0) {
 			log_warn("netlink", "unable to get SO_SNDBUF");
 		} else {
-			if (got != sndbuf)
+			if (got < sndbuf)
 				log_warnx("netlink", "tried to set SO_SNDBUF to '%d' "
 				    "but got '%d'", sndbuf, got);
 		}
@@ -77,7 +77,7 @@ netlink_socket_set_buffer_sizes(int s, int sndbuf, int rcvbuf)
 		if (getsockopt(s, SOL_SOCKET, SO_RCVBUF, &got, &size) < 0) {
 			log_warn("netlink", "unable to get SO_RCVBUF");
 		} else {
-			if (got != rcvbuf)
+			if (got < rcvbuf)
 				log_warnx("netlink", "tried to set SO_RCVBUF to '%d' "
 				    "but got '%d'", rcvbuf, got);
 		}
@@ -113,8 +113,8 @@ netlink_socket_double_buffer_sizes(int s, int max)
 			log_warn("netlink", "unable to get SO_RCVBUF");
 			return -1;
 		}
-		if (got != current) {
-			log_warn("netlink", "tried to set SO_RCVBUF to '%d' "
+		if (got < current) {
+			log_warnx("netlink", "tried to set SO_RCVBUF to '%d' "
 			    "but got '%d'", current, got);
 			return 1; /* Assume we got the maximum */
 		}

--- a/src/daemon/netlink.c
+++ b/src/daemon/netlink.c
@@ -28,13 +28,6 @@
 
 #define NETLINK_BUFFER 4096
 
-#ifndef RTNL_SND_BUFSIZE
-#define RTNL_SND_BUFSIZE	32 * 1024
-#endif
-#ifndef RTNL_RCV_BUFSIZE
-#define RTNL_RCV_BUFSIZE	256 * 1024
-#endif
-
 struct netlink_req {
 	struct nlmsghdr hdr;
 	struct rtgenmsg gen;
@@ -51,8 +44,8 @@ struct lldpd_netlink {
 static int
 netlink_socket_set_buffer_sizes(int s)
 {
-	int sndbuf = RTNL_SND_BUFSIZE;
-	int rcvbuf = RTNL_RCV_BUFSIZE;
+	int sndbuf = NETLINK_SEND_BUFSIZE;
+	int rcvbuf = NETLINK_RECEIVE_BUFSIZE;
 	socklen_t size = 0;
 	int got = 0;
 

--- a/src/daemon/netlink.c
+++ b/src/daemon/netlink.c
@@ -49,12 +49,12 @@ netlink_socket_set_buffer_sizes(int s)
 	socklen_t size = 0;
 	int got = 0;
 
-	if (setsockopt(s, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf)) < 0) {
+	if (sndbuf > 0 && setsockopt(s, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf)) < 0) {
 		log_warn("netlink", "unable to set SO_SNDBUF to '%d'", sndbuf);
 		return -1;
 	}
 
-	if (setsockopt(s, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf)) < 0) {
+	if (rcvbuf > 0 && setsockopt(s, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf)) < 0) {
 		log_warn("netlink", "unable to set SO_RCVBUF to '%d'", rcvbuf);
 		return -1;
 	}
@@ -64,26 +64,30 @@ netlink_socket_set_buffer_sizes(int s)
 	 * `net.core.wmem_max`. This it the easiest [probably sanest too]
 	 * to validate that our socket buffers were set properly.
 	 */
-	if (getsockopt(s, SOL_SOCKET, SO_SNDBUF, &got, &size) < 0) {
-		log_warn("netlink", "unable to get SO_SNDBUF");
-	} else {
-		if (size != sizeof(sndbuf))
-			log_warn("netlink", "size mismatch for SO_SNDBUF got '%u' "
-			         "should be '%zu'", size, sizeof(sndbuf));
-		if (got != sndbuf)
-			log_warn("netlink", "tried to set SO_SNDBUF to '%d' "
-			         "but got '%d'", sndbuf, got);
+	if (sndbuf > 0) {
+		if (getsockopt(s, SOL_SOCKET, SO_SNDBUF, &got, &size) < 0) {
+			log_warn("netlink", "unable to get SO_SNDBUF");
+		} else {
+			if (size != sizeof(sndbuf))
+				log_warn("netlink", "size mismatch for SO_SNDBUF got '%u' "
+				    "should be '%zu'", size, sizeof(sndbuf));
+			if (got != sndbuf)
+				log_warn("netlink", "tried to set SO_SNDBUF to '%d' "
+				    "but got '%d'", sndbuf, got);
+		}
 	}
 
-	if (getsockopt(s, SOL_SOCKET, SO_RCVBUF, &got, &size) < 0) {
-		log_warn("netlink", "unable to get SO_RCVBUF");
-	} else {
-		if (size != sizeof(rcvbuf))
-			log_warn("netlink", "size mismatch for SO_RCVBUF got '%u' "
-			         "should be '%zu'", size, sizeof(rcvbuf));
-		if (got != rcvbuf)
-			log_warn("netlink", "tried to set SO_RCVBUF to '%d' "
-			         "but got '%d'", rcvbuf, got);
+	if (rcvbuf > 0) {
+		if (getsockopt(s, SOL_SOCKET, SO_RCVBUF, &got, &size) < 0) {
+			log_warn("netlink", "unable to get SO_RCVBUF");
+		} else {
+			if (size != sizeof(rcvbuf))
+				log_warn("netlink", "size mismatch for SO_RCVBUF got '%u' "
+				    "should be '%zu'", size, sizeof(rcvbuf));
+			if (got != rcvbuf)
+				log_warn("netlink", "tried to set SO_RCVBUF to '%d' "
+				    "but got '%d'", rcvbuf, got);
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
When netlink socket receive buffer is too small, increase it automatically up to a compile-time limit.

@commodo, there are some changes compared to your PR:
 - use of `<` instead of `!=` as the kernel seems to round the result
 - by default, we don't change the buffer size
 - removed a check about the size of the int returned by the kernel (don't think that's useful)

I have tried with very small buffers and it seems to work.