### PR TITLE
lldp: attach remote TTL to port instead of chassis

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 lldpd (0.9.7)
   * Changes:
+    + Attach remote TTL to port instead of chassis.
     + JSON support is now built-in and unconditionally enabled. Use
       --enable-json0 to keep the pre-0.9.2 json-c format.
     + When logging to syslog and daemonizing, don't log to stderr.

--- a/src/client/display.c
+++ b/src/client/display.c
@@ -252,9 +252,6 @@ display_chassis(struct writer* w, lldpctl_atom_t* chassis, int details)
 	}
 	tag_datatag(w, "descr", "SysDescr",
 	    lldpctl_atom_get_str(chassis, lldpctl_k_chassis_descr));
-	if (details && lldpctl_atom_get_int(chassis, lldpctl_k_chassis_ttl) > 0)
-		tag_datatag(w, "ttl", "TTL",
-		    lldpctl_atom_get_str(chassis, lldpctl_k_chassis_ttl));
 
 	/* Management addresses */
 	mgmts = lldpctl_atom_get(chassis, lldpctl_k_chassis_mgmt);

--- a/src/client/display.c
+++ b/src/client/display.c
@@ -252,7 +252,7 @@ display_chassis(struct writer* w, lldpctl_atom_t* chassis, int details)
 	}
 	tag_datatag(w, "descr", "SysDescr",
 	    lldpctl_atom_get_str(chassis, lldpctl_k_chassis_descr));
-	if (details)
+	if (details && lldpctl_atom_get_int(chassis, lldpctl_k_chassis_ttl) > 0)
 		tag_datatag(w, "ttl", "TTL",
 		    lldpctl_atom_get_str(chassis, lldpctl_k_chassis_ttl));
 
@@ -352,6 +352,9 @@ display_port(struct writer *w, lldpctl_atom_t *port, int details)
 
 	tag_datatag(w, "descr", "PortDescr",
 	    lldpctl_atom_get_str(port, lldpctl_k_port_descr));
+	if (details)
+		tag_datatag(w, "ttl", "TTL",
+		    lldpctl_atom_get_str(port, lldpctl_k_port_ttl));
 
 	/* Dot3 */
 	if (details == DISPLAY_DETAILS) {

--- a/src/daemon/agent.c
+++ b/src/daemon/agent.c
@@ -606,7 +606,7 @@ agent_h_scalars(struct variable *vp, oid *name, size_t *length,
                 long_ret = scfg->g_config.c_tx_interval;
 		return (u_char *)&long_ret;
 	case LLDP_SNMP_TXMULTIPLIER:
-		long_ret = LOCAL_CHASSIS(scfg)->c_ttl / scfg->g_config.c_tx_interval;
+		long_ret = scfg->g_config.c_ttl / scfg->g_config.c_tx_interval;
 		return (u_char *)&long_ret;
 	case LLDP_SNMP_REINITDELAY:
 		long_ret = 1;

--- a/src/daemon/client.c
+++ b/src/daemon/client.c
@@ -76,7 +76,7 @@ client_handle_set_configuration(struct lldpd *cfg, enum hmsg_type *type,
 			log_debug("rpc", "client change transmit interval to %d",
 			    config->c_tx_interval);
 			cfg->g_config.c_tx_interval = config->c_tx_interval;
-			LOCAL_CHASSIS(cfg)->c_ttl = cfg->g_config.c_tx_interval *
+			cfg->g_config.c_ttl = cfg->g_config.c_tx_interval *
 			    cfg->g_config.c_tx_hold;
 		}
 	}
@@ -84,7 +84,7 @@ client_handle_set_configuration(struct lldpd *cfg, enum hmsg_type *type,
 		log_debug("rpc", "client change transmit hold to %d",
 		    config->c_tx_hold);
 		cfg->g_config.c_tx_hold = config->c_tx_hold;
-		LOCAL_CHASSIS(cfg)->c_ttl = cfg->g_config.c_tx_interval *
+		cfg->g_config.c_ttl = cfg->g_config.c_tx_interval *
 		    cfg->g_config.c_tx_hold;
 	}
 	if (CHANGED(c_lldp_portid_type) &&

--- a/src/daemon/event.c
+++ b/src/daemon/event.c
@@ -804,16 +804,16 @@ levent_schedule_cleanup(struct lldpd *cfg)
 	struct lldpd_port *port;
 	TAILQ_FOREACH(hardware, &cfg->g_hardware, h_entries) {
 		TAILQ_FOREACH(port, &hardware->h_rports, p_entries) {
-			if (now >= port->p_lastupdate + port->p_chassis->c_ttl) {
+			if (now >= port->p_lastupdate + port->p_ttl) {
 				tv.tv_sec = 0;
 				log_debug("event", "immediate cleanup on port %s (%lld, %d, %lld)",
 				    hardware->h_ifname,
 				    (long long)now,
-				    port->p_chassis->c_ttl,
+				    port->p_ttl,
 				    (long long)port->p_lastupdate);
 				break;
 			}
-			next = port->p_chassis->c_ttl - (now - port->p_lastupdate);
+			next = port->p_ttl - (now - port->p_lastupdate);
 			if (next < tv.tv_sec)
 				tv.tv_sec = next;
 		}

--- a/src/daemon/event.c
+++ b/src/daemon/event.c
@@ -797,7 +797,7 @@ levent_schedule_cleanup(struct lldpd *cfg)
 	}
 
 	/* Compute the next TTL event */
-	struct timeval tv = { LOCAL_CHASSIS(cfg)->c_ttl, 0 };
+	struct timeval tv = { cfg->g_config.c_ttl, 0 };
 	time_t now = time(NULL);
 	time_t next;
 	struct lldpd_hardware *hardware;

--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -1768,6 +1768,7 @@ lldpd_main(int argc, char *argv[], char *envp[])
 	cfg->g_config.c_receiveonly = receiveonly;
 	cfg->g_config.c_tx_interval = LLDPD_TX_INTERVAL;
 	cfg->g_config.c_tx_hold = LLDPD_TX_HOLD;
+	cfg->g_config.c_ttl = cfg->g_config.c_tx_interval * cfg->g_config.c_tx_hold;
 	cfg->g_config.c_max_neighbors = LLDPD_MAX_NEIGHBORS;
 #ifdef ENABLE_LLDPMED
 	cfg->g_config.c_enable_fast_start = enable_fast_start;
@@ -1819,9 +1820,6 @@ lldpd_main(int argc, char *argv[], char *envp[])
 	} else
 		cfg->g_config.c_noinventory = 1;
 #endif
-
-	/* Set TTL */
-	lchassis->c_ttl = cfg->g_config.c_tx_interval * cfg->g_config.c_tx_hold;
 
 	log_debug("main", "initialize protocols");
 	cfg->g_protocols = protos;

--- a/src/daemon/protocols/cdp.c
+++ b/src/daemon/protocols/cdp.c
@@ -87,7 +87,7 @@ cdp_send(struct lldpd *global,
 	if (!(
 	      POKE_SAVE(pos_cdp) &&
 	      POKE_UINT8((version == 0)?1:version) &&
-	      POKE_UINT8(chassis->c_ttl) &&
+	      POKE_UINT8(global?global->g_config.c_ttl:180) &&
 	      POKE_SAVE(pos_checksum) && /* Save checksum position */
 	      POKE_UINT16(0)))
 		goto toobig;

--- a/src/daemon/protocols/cdp.c
+++ b/src/daemon/protocols/cdp.c
@@ -358,7 +358,7 @@ cdp_decode(struct lldpd *cfg, char *frame, int s,
 		    version, hardware->h_ifname);
 		goto malformed;
 	}
-	chassis->c_ttl = PEEK_UINT8; /* TTL */
+	port->p_ttl = PEEK_UINT8; /* TTL */
 	PEEK_DISCARD_UINT16;	     /* Checksum, already checked */
 
 	while (length) {
@@ -563,7 +563,7 @@ cdp_decode(struct lldpd *cfg, char *frame, int s,
 	    (chassis->c_name == NULL) ||
 	    (chassis->c_descr == NULL) ||
 	    (port->p_descr == NULL) ||
-	    (chassis->c_ttl == 0) ||
+	    (port->p_ttl == 0) ||
 	    (chassis->c_cap_enabled == 0)) {
 		log_warnx("cdp", "some mandatory CDP/FDP tlv are missing for frame received on %s",
 		    hardware->h_ifname);

--- a/src/daemon/protocols/edp.c
+++ b/src/daemon/protocols/edp.c
@@ -307,7 +307,7 @@ edp_decode(struct lldpd *cfg, char *frame, int s,
 		    hardware->h_ifname);
 		goto malformed;
 	}
-	chassis->c_ttl = cfg?cfg->g_config.c_tx_interval * cfg->g_config.c_tx_hold:0;
+	port->p_ttl = cfg?cfg->g_config.c_tx_interval * cfg->g_config.c_tx_hold:0;
 	chassis->c_id_subtype = LLDP_CHASSISID_SUBTYPE_LLADDR;
 	chassis->c_id_len = ETHER_ADDR_LEN;
 	if ((chassis->c_id = (char *)malloc(ETHER_ADDR_LEN)) == NULL) {

--- a/src/daemon/protocols/lldp.c
+++ b/src/daemon/protocols/lldp.c
@@ -131,7 +131,7 @@ static int _lldp_send(struct lldpd *global,
 	/* Time to live */
 	if (!(
 	      POKE_START_LLDP_TLV(LLDP_TLV_TTL) &&
-	      POKE_UINT16(shutdown?0:chassis->c_ttl) &&
+	      POKE_UINT16(shutdown?0:(global?global->g_config.c_ttl:180)) &&
 	      POKE_END_LLDP_TLV))
 		goto toobig;
 

--- a/src/daemon/protocols/lldp.c
+++ b/src/daemon/protocols/lldp.c
@@ -707,7 +707,7 @@ lldp_decode(struct lldpd *cfg, char *frame, int s,
 			break;
 		case LLDP_TLV_TTL:
 			CHECK_TLV_SIZE(2, "TTL");
-			chassis->c_ttl = PEEK_UINT16;
+			port->p_ttl = PEEK_UINT16;
 			ttl_received = 1;
 			break;
 		case LLDP_TLV_PORT_DESCR:

--- a/src/daemon/protocols/sonmp.c
+++ b/src/daemon/protocols/sonmp.c
@@ -365,7 +365,7 @@ sonmp_decode(struct lldpd *cfg, char *frame, int s,
 		goto malformed;
 	}
 	TAILQ_INSERT_TAIL(&chassis->c_mgmt, mgmt, m_entries);
-	chassis->c_ttl = cfg?(cfg->g_config.c_tx_interval * cfg->g_config.c_tx_hold):
+	port->p_ttl = cfg?(cfg->g_config.c_tx_interval * cfg->g_config.c_tx_hold):
 	    LLDPD_TTL;
 
 	port->p_id_subtype = LLDP_PORTID_SUBTYPE_LOCAL;

--- a/src/lib/atoms/chassis.c
+++ b/src/lib/atoms/chassis.c
@@ -186,8 +186,6 @@ _lldpctl_atom_get_int_chassis(lldpctl_atom_t *atom, lldpctl_key_t key)
 		return chassis->c_cap_available;
 	case lldpctl_k_chassis_cap_enabled:
 		return chassis->c_cap_enabled;
-	case lldpctl_k_chassis_ttl:
-		return chassis->c_ttl;
 #ifdef ENABLE_LLDPMED
 	case lldpctl_k_chassis_med_type:
 		return chassis->c_med_type;

--- a/src/lib/atoms/port.c
+++ b/src/lib/atoms/port.c
@@ -616,6 +616,8 @@ _lldpctl_atom_get_int_port(lldpctl_atom_t *atom, lldpctl_key_t key)
 		return port->p_protocol;
 	case lldpctl_k_port_age:
 		return port->p_lastchange;
+	case lldpctl_k_port_ttl:
+		return port->p_ttl;
 	case lldpctl_k_port_id_subtype:
 		return port->p_id_subtype;
 	case lldpctl_k_port_hidden:

--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -684,6 +684,7 @@ typedef enum {
 	lldpctl_k_port_hidden,	   /**< `(I)` Is this port hidden (or should it be displayed?)? */
 	lldpctl_k_port_status,	   /**< `(IS,WO)` Operational status of this (local) port */
 	lldpctl_k_port_chassis,	   /**< `(A)` Chassis associated to the port */
+	lldpctl_k_port_ttl,        /**< `(I)` TTL for port, 0 if info is attached to chassis */
 
 	lldpctl_k_port_dot3_mfs = 1300,	   /**< `(I)` MFS */
 	lldpctl_k_port_dot3_aggregid,   /**< `(I)` Port aggregation ID */

--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -726,7 +726,7 @@ typedef enum {
 	lldpctl_k_chassis_cap_available, /**< `(I)` Available capabalities (see `LLDP_CAP_*`) */
 	lldpctl_k_chassis_cap_enabled,	 /**< `(I)` Enabled capabilities (see `LLDP_CAP_*`) */
 	lldpctl_k_chassis_mgmt,		 /**< `(AL)` List of management addresses */
-	lldpctl_k_chassis_ttl,		 /**< `(I)` The chassis TTL */
+	lldpctl_k_chassis_ttl,		 /**< Deprecated */
 
 	lldpctl_k_chassis_med_type = 1900, /**< `(IS)` Chassis MED type. See `LLDP_MED_CLASS_*` */
 	lldpctl_k_chassis_med_cap,  /**< `(I)` Available MED capabilitied. See `LLDP_MED_CAP_*` */

--- a/src/lldpd-structs.c
+++ b/src/lldpd-structs.c
@@ -174,7 +174,7 @@ lldpd_remote_cleanup(struct lldpd_hardware *hardware,
 		port_next = TAILQ_NEXT(port, p_entries);
 		del = all;
 		if (!all && expire &&
-		    (now >= port->p_lastupdate + port->p_chassis->c_ttl)) {
+		    (now >= port->p_lastupdate + port->p_ttl)) {
 			hardware->h_ageout_cnt++;
 			hardware->h_delete_cnt++;
 			del = 1;

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -178,8 +178,6 @@ struct lldpd_chassis {
 	u_int16_t		 c_cap_available;
 	u_int16_t		 c_cap_enabled;
 
-	u_int16_t		 c_ttl; /* TTL for local chassis */
-
 	TAILQ_HEAD(, lldpd_mgmt) c_mgmt;
 
 #ifdef ENABLE_LLDPMED
@@ -373,6 +371,7 @@ MARSHAL_END(lldpd_port_set);
 struct lldpd_config {
 	int c_paused;	        /* lldpd is paused */
 	int c_tx_interval;	/* Transmit interval */
+	int c_ttl;		/* TTL */
 	int c_smart;		/* Bitmask for smart configuration (see SMART_*) */
 	int c_receiveonly;	/* Receive only mode */
 	int c_max_neighbors;	/* Maximum number of neighbors (per protocol) */

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -178,7 +178,7 @@ struct lldpd_chassis {
 	u_int16_t		 c_cap_available;
 	u_int16_t		 c_cap_enabled;
 
-	u_int16_t		 c_ttl;
+	u_int16_t		 c_ttl; /* TTL for local chassis */
 
 	TAILQ_HEAD(, lldpd_mgmt) c_mgmt;
 
@@ -261,6 +261,7 @@ struct lldpd_port {
 	char			*p_descr;
 	int			 p_descr_force; /* Description has been forced by user */
 	u_int16_t		 p_mfs;
+	u_int16_t		 p_ttl; /* TTL for remote port */
 
 #ifdef ENABLE_DOT3
 	/* Dot3 stuff */

--- a/tests/check_cdp.c
+++ b/tests/check_cdp.c
@@ -109,6 +109,7 @@ Cisco Discovery Protocol
 	struct lldpd_mgmt *mgmt;
 	struct lldpd cfg = {
 		.g_config = {
+			.c_ttl = 180,
 			.c_platform = "Linux"
 		}
 	};
@@ -243,6 +244,7 @@ Cisco Discovery Protocol
 	struct lldpd_mgmt *mgmt2;
 	struct lldpd cfg = {
 		.g_config = {
+			.c_ttl = 180,
 			.c_platform = "Linux"
 		}
 	};

--- a/tests/check_lldp.c
+++ b/tests/check_lldp.c
@@ -513,10 +513,10 @@ Link Layer Discovery Protocol
 	    LLDP_PORTID_SUBTYPE_LLADDR);
 	ck_assert_int_eq(nport->p_id_len, ETHER_ADDR_LEN);
 	fail_unless(memcmp(mac2, nport->p_id, ETHER_ADDR_LEN) == 0);
-	ck_assert_int_eq(nchassis->c_ttl, 120);
 	ck_assert_ptr_eq(nchassis->c_name, NULL);
 	ck_assert_ptr_eq(nchassis->c_descr, NULL);
 	ck_assert_ptr_eq(nport->p_descr, NULL);
+	ck_assert_int_eq(nport->p_ttl, 120);
 }
 END_TEST
 
@@ -718,7 +718,7 @@ Link Layer Discovery Protocol
 	    LLDP_PORTID_SUBTYPE_LLADDR);
 	ck_assert_int_eq(nport->p_id_len, ETHER_ADDR_LEN);
 	fail_unless(memcmp(mac1, nport->p_id, ETHER_ADDR_LEN) == 0);
-	ck_assert_int_eq(nchassis->c_ttl, 120);
+	ck_assert_int_eq(nport->p_ttl, 120);
 	ck_assert_str_eq(nchassis->c_name, "naruto.XXXXXXXXXXXXXXXXXXX");
 	ck_assert_str_eq(nchassis->c_descr,
 	    "Linux 2.6.29-2-amd64 #1 SMP Sun May 17 17:15:47 UTC 2009 x86_64");

--- a/tests/check_snmp.c
+++ b/tests/check_snmp.c
@@ -33,6 +33,7 @@ extern struct variable8 agent_lldp_vars[];
 struct lldpd test_cfg = {
 	.g_config = {
 		.c_tx_interval = 30,
+		.c_ttl = 60,
 		.c_smart = 0
 	}
 };
@@ -55,7 +56,6 @@ struct lldpd_chassis chassis1 = {
 	.c_descr         = "First chassis",
 	.c_cap_available = LLDP_CAP_BRIDGE | LLDP_CAP_WLAN | LLDP_CAP_ROUTER,
 	.c_cap_enabled   = LLDP_CAP_ROUTER,
-	.c_ttl           = 60,
 #ifdef ENABLE_LLDPMED
 	.c_med_cap_available = LLDP_MED_CAP_CAP | LLDP_MED_CAP_IV | \
 		LLDP_MED_CAP_LOCATION |	LLDP_MED_CAP_POLICY | \
@@ -96,7 +96,6 @@ struct lldpd_chassis chassis2 = {
 	.c_descr         = "Second chassis",
 	.c_cap_available = LLDP_CAP_ROUTER,
 	.c_cap_enabled   = LLDP_CAP_ROUTER,
-	.c_ttl           = 60,
 #ifdef ENABLE_LLDPMED
 	.c_med_hw     = "Hardware 2",
 	/* We skip c_med_fw */

--- a/tests/common.c
+++ b/tests/common.c
@@ -124,7 +124,6 @@ pcap_setup()
 	/* Prepare chassis */
 	memset(&chassis, 0, sizeof(struct lldpd_chassis));
 	hardware.h_lport.p_chassis = &chassis;
-	chassis.c_ttl = 180;
 }
 
 void

--- a/tests/decode.c
+++ b/tests/decode.c
@@ -139,7 +139,6 @@ main(int argc, char **argv)
 	printf(" Description: %s\n", nchassis->c_descr?nchassis->c_descr:"(null)");
 	printf(" Cap available: %" PRIu16 "\n", nchassis->c_cap_available);
 	printf(" Cap enabled: %" PRIu16 "\n", nchassis->c_cap_enabled);
-	printf(" TTL: %" PRIu16 "\n", nchassis->c_ttl);
 	struct lldpd_mgmt *mgmt;
 	TAILQ_FOREACH(mgmt, &nchassis->c_mgmt, m_entries) {
 		char ipaddress[INET6_ADDRSTRLEN + 1];

--- a/tests/decode.c
+++ b/tests/decode.c
@@ -178,6 +178,7 @@ main(int argc, char **argv)
 	printf(" ID: %s\n", tohex(nport->p_id, nport->p_id_len));
 	printf(" Description: %s\n", nport->p_descr?nport->p_descr:"(null)");
 	printf(" MFS: %" PRIu16 "\n", nport->p_mfs);
+	printf(" TTL: %" PRIu16 "\n", nport->p_ttl);
 #ifdef ENABLE_DOT3
 	printf(" Dot3 aggrID: %" PRIu32 "\n", nport->p_aggregid);
 	printf(" Dot3 MAC/phy autoneg supported: %" PRIu8 "\n", nport->p_macphy.autoneg_support);

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -21,12 +21,12 @@ def test_one_neighbor(lldpd1, lldpd, lldpcli, namespaces):
                        "lldp.eth0.rid": "1",
                        "lldp.eth0.chassis.mac": "00:00:00:00:00:02",
                        "lldp.eth0.chassis.name": "ns-2.example.com",
-                       "lldp.eth0.chassis.ttl": "120",
                        "lldp.eth0.chassis.mgmt-ip": "fe80::200:ff:fe00:2",
                        "lldp.eth0.chassis.Bridge.enabled": "off",
                        "lldp.eth0.chassis.Wlan.enabled": "off",
                        "lldp.eth0.port.mac": "00:00:00:00:00:02",
-                       "lldp.eth0.port.descr": "eth1"}
+                       "lldp.eth0.port.descr": "eth1",
+                       "lldp.eth0.port.ttl": "120"}
 
 
 @pytest.mark.parametrize("neighbors", (5, 10, 20))

--- a/tests/integration/test_lldpcli.py
+++ b/tests/integration/test_lldpcli.py
@@ -35,7 +35,6 @@ Interface:    eth0, via: LLDP, RID: 1, Time: 0 day, 00:00:{seconds}
     ChassisID:    mac 00:00:00:00:00:02
     SysName:      ns-2.example.com
     SysDescr:     Spectacular GNU/Linux 2016 {uname}
-    TTL:          120
     MgmtIP:       fe80::200:ff:fe00:2
     Capability:   Bridge, off
     Capability:   Router, {router}
@@ -43,7 +42,8 @@ Interface:    eth0, via: LLDP, RID: 1, Time: 0 day, 00:00:{seconds}
     Capability:   Station, {station}
   Port:
     PortID:       mac 00:00:00:00:00:02
-    PortDescr:    eth1{dot3}
+    PortDescr:    eth1
+    TTL:          120{dot3}
 -------------------------------------------------------------------------------
 """
         out = result.stdout.decode('ascii')
@@ -90,7 +90,6 @@ def test_json_output(lldpd1, lldpd, lldpcli, namespaces, uname):
                             "value": "00:00:00:00:00:02"
                         },
                         "descr": "Spectacular GNU/Linux 2016 {}".format(uname),
-                        "ttl": "120",
                         "mgmt-ip": "fe80::200:ff:fe00:2",
                         "capability": [
                             {"type": "Bridge", "enabled": False},
@@ -103,7 +102,8 @@ def test_json_output(lldpd1, lldpd, lldpcli, namespaces, uname):
                         "type": "mac",
                         "value": "00:00:00:00:00:02"
                     },
-                    "descr": "eth1"
+                    "descr": "eth1",
+                    "ttl": "120"
                 }
             }}
         }}
@@ -147,7 +147,6 @@ def test_xml_output(lldpd1, lldpd, lldpcli, namespaces, uname):
    <id label="ChassisID" type="mac">00:00:00:00:00:02</id>
    <name label="SysName">ns-2.example.com</name>
    <descr label="SysDescr">Spectacular GNU/Linux 2016 {uname}</descr>
-   <ttl label="TTL">120</ttl>
    <mgmt-ip label="MgmtIP">fe80::200:ff:fe00:2</mgmt-ip>
    <capability label="Capability" type="Bridge" enabled="off"/>
    <capability label="Capability" type="Router" enabled="{router}"/>
@@ -156,7 +155,8 @@ def test_xml_output(lldpd1, lldpd, lldpcli, namespaces, uname):
   </chassis>
   <port label="Port">
    <id label="PortID" type="mac">00:00:00:00:00:02</id>
-   <descr label="PortDescr">eth1</descr>{dot3}
+   <descr label="PortDescr">eth1</descr>
+   <ttl label="TTL">120</ttl>{dot3}
   </port>
  </interface>
 </lldp>

--- a/tests/integration/test_pcap.py
+++ b/tests/integration/test_pcap.py
@@ -36,7 +36,7 @@ class TestPcapCaptures(object):
                 "lldp.eth0.via": "LLDP",
                 "lldp.eth0.rid": "1",
                 "lldp.eth0.chassis.mac": "00:35:35:35:35:35",
-                "lldp.eth0.chassis.ttl": "120",
+                "lldp.eth0.port.ttl": "120",
                 "lldp.eth0.port.ifname": "g1",
             }
             if 'Dot3' in pytest.config.lldpd.features:


### PR DESCRIPTION
When receiving a 0 TTL, we should trigger expiry of the remote port, not
the remote chassis. Therefore, TTL is moved to port. This fixes two cases:

 - a shutdown LLDPU should only expire one local port
 - when a port is refreshed, another port of the same chassis shouldn't
   be refreshed

Fix #221 