### PR TITLE
Increase number of lldp neighbors to 32.

### DIFF
--- a/src/daemon/lldpd.h
+++ b/src/daemon/lldpd.h
@@ -85,7 +85,7 @@ struct event_base;
 #define LLDPD_TX_HOLD          4
 #define LLDPD_TTL              LLDPD_TX_INTERVAL * LLDPD_TX_HOLD
 #define LLDPD_TX_MSGDELAY	1
-#define LLDPD_MAX_NEIGHBORS	4
+#define LLDPD_MAX_NEIGHBORS	32
 #define LLDPD_FAST_TX_INTERVAL	1
 #define LLDPD_FAST_INIT	4
 


### PR DESCRIPTION
In our company we have multiple situation where a number of devices are connected to a un-managed switch. So this gives a number higher number of lldp neighbors in the remote table.