### PR TITLE
lldp: clear station bit if any other capability is enabled

### DIFF
--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -1159,6 +1159,8 @@ lldpd_update_localchassis(struct lldpd *cfg)
 	if ((LOCAL_CHASSIS(cfg)->c_cap_available & LLDP_CAP_STATION) &&
 		(LOCAL_CHASSIS(cfg)->c_cap_enabled == 0))
 		LOCAL_CHASSIS(cfg)->c_cap_enabled = LLDP_CAP_STATION;
+	else if (LOCAL_CHASSIS(cfg)->c_cap_enabled != LLDP_CAP_STATION)
+		LOCAL_CHASSIS(cfg)->c_cap_enabled &= ~LLDP_CAP_STATION;
 
 	/* Set chassis ID if needed. This is only done if chassis ID
 	   has not been set previously (with the MAC address of an


### PR DESCRIPTION
The 801.1AB spec states that the station only capability should
not be set in conjunction with any other (capability) bits.

It is possible for the lldpd interface update routine to set the
station bit, while the lldpd chassis update routine may, at a later
time, set the router capability bit. In this case the station bit
is not cleared.

This commit clears the station bit if any other capability is set.