### PR TITLE
priv: don't run ethtool as root

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@ lldpd (0.9.8)
     + Use ethtool to get permanent address for bonds and teams. This
       might provide different results than the previous method. Some
       devices may still use the previous method.
+    + Don't run ethtool as root. Kernels older than 2.6.19 won't get
+      link information anymore.
   * Fixes:
     + Handle team interfaces like a bond. Real MAC address cannot be
       retrieved yet.

--- a/src/daemon/interfaces-linux.c
+++ b/src/daemon/interfaces-linux.c
@@ -432,6 +432,7 @@ iflinux_get_permanent_mac(struct lldpd *cfg,
 		iflinux_get_permanent_mac_bond(cfg, interfaces, iface);
 }
 
+#ifdef ENABLE_DOT3
 #define ETHTOOL_LINK_MODE_MASK_MAX_KERNEL_NU32 (SCHAR_MAX)
 #define ETHTOOL_DECLARE_LINK_MODE_MASK(name)			\
 	uint32_t name[ETHTOOL_LINK_MODE_MASK_MAX_KERNEL_NU32]
@@ -551,7 +552,6 @@ end:
 static void
 iflinux_macphy(struct lldpd *cfg, struct lldpd_hardware *hardware)
 {
-#ifdef ENABLE_DOT3
 	struct ethtool_link_usettings uset;
 	struct lldpd_port *port = &hardware->h_lport;
 	int j;
@@ -643,8 +643,14 @@ iflinux_macphy(struct lldpd *cfg, struct lldpd_hardware *hardware)
 		}
 		if (uset.base.port == PORT_AUI) port->p_macphy.mau_type = LLDP_DOT3_MAU_AUI;
 	}
-#endif
 }
+#else /* ENABLE_DOT3 */
+static void
+iflinux_macphy(struct lldpd *cfg, struct lldpd_hardware *hardware)
+{
+}
+#endif /* ENABLE_DOT3 */
+
 
 struct bond_master {
 	char name[IFNAMSIZ];

--- a/src/daemon/interfaces-linux.c
+++ b/src/daemon/interfaces-linux.c
@@ -494,7 +494,7 @@ iflinux_ethtool_glink(struct lldpd *cfg, const char *ifname, struct ethtool_link
 		if (rc == 0) {
 			nwords = -ecmd.req.link_mode_masks_nwords;
 			log_debug("interfaces", "glinksettings nwords is %" PRId8, nwords);
-		}
+		} else nwords = -1;
 	}
 	if (nwords > 0) {
 		memset(&ecmd, 0, sizeof(ecmd));

--- a/src/daemon/lldpd.h
+++ b/src/daemon/lldpd.h
@@ -37,17 +37,6 @@
 #include <netinet/in.h>
 #include <sys/un.h>
 
-#ifdef HOST_OS_LINUX
-# if defined(__clang__)
-#  pragma clang diagnostic push
-#  pragma clang diagnostic ignored "-Wdocumentation"
-# endif
-# include <linux/ethtool.h>
-# if defined(__clang__)
-#  pragma clang diagnostic pop
-# endif
-#endif
-
 #if HAVE_VFORK_H
 # include <vfork.h>
 #endif
@@ -212,22 +201,8 @@ void	 priv_wait(void);
 void	 priv_ctl_cleanup(const char *ctlname);
 char   	*priv_gethostname(void);
 #ifdef HOST_OS_LINUX
-#define ETHTOOL_LINK_MODE_MASK_MAX_KERNEL_NU32 (SCHAR_MAX)
-#define ETHTOOL_DECLARE_LINK_MODE_MASK(name)			\
-	uint32_t name[ETHTOOL_LINK_MODE_MASK_MAX_KERNEL_NU32]
-
-struct ethtool_link_usettings {
-	struct ethtool_link_settings base;
-	struct {
-		ETHTOOL_DECLARE_LINK_MODE_MASK(supported);
-		ETHTOOL_DECLARE_LINK_MODE_MASK(advertising);
-		ETHTOOL_DECLARE_LINK_MODE_MASK(lp_advertising);
-	} link_modes;
-};
 int    	 priv_open(char*);
 void	 asroot_open(void);
-int    	 priv_ethtool(char*, struct ethtool_link_usettings*);
-void	 asroot_ethtool(void);
 #endif
 int    	 priv_iface_init(int, char *);
 int	 asroot_iface_init_os(int, char *, int *);
@@ -243,7 +218,6 @@ enum priv_cmd {
 	PRIV_DELETE_CTL_SOCKET,
 	PRIV_GET_HOSTNAME,
 	PRIV_OPEN,
-	PRIV_ETHTOOL,
 	PRIV_IFACE_INIT,
 	PRIV_IFACE_MULTICAST,
 	PRIV_IFACE_DESCRIPTION,

--- a/src/daemon/priv.c
+++ b/src/daemon/priv.c
@@ -387,7 +387,6 @@ static struct dispatch_actions actions[] = {
 	{PRIV_GET_HOSTNAME, asroot_gethostname},
 #ifdef HOST_OS_LINUX
 	{PRIV_OPEN, asroot_open},
-	{PRIV_ETHTOOL, asroot_ethtool},
 #endif
 	{PRIV_IFACE_INIT, asroot_iface_init},
 	{PRIV_IFACE_MULTICAST, asroot_iface_multicast},


### PR DESCRIPTION
Kernels older than 2.6.19 won't get any link information. Kernels 4.6,
4.7 and 4.8 won't get information from GLINKSETTINGS (higher speeds)
but they are not LTS kernels so we should be fine. This removes a
bunch of code.