### PR TITLE
client: add show interfaces command

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -131,6 +131,8 @@ void display_interfaces_stats(lldpctl_conn_t *, struct writer *,
     struct cmd_env *);
 void display_interface_stats(lldpctl_conn_t *, struct writer *,
     lldpctl_atom_t *);
+void display_local_interfaces(lldpctl_conn_t *, struct writer *,
+    struct cmd_env *, int, int);
 
 
 

--- a/src/client/display.c
+++ b/src/client/display.c
@@ -494,12 +494,14 @@ display_local_ttl(struct writer *w, lldpctl_conn_t *conn, int details)
 
 	if (asprintf(&ttl, "%lu", tx_hold*tx_interval) == -1) {
 		log_warnx("lldpctl", "not enough memory to build TTL.");
+		goto end;
 	}
 
 	tag_start(w, "ttl", "TTL");
 	tag_attr(w, "ttl", "", ttl);
 	tag_end(w);
 	free(ttl);
+end:
 	lldpctl_atom_dec_ref(configuration);
 	return;
 }
@@ -731,29 +733,9 @@ display_local_interfaces(lldpctl_conn_t *conn, struct writer *w,
 {
 	lldpctl_atom_t *iface;
 	int protocol = LLDPD_MODE_MAX;
-	const char *proto_str;
-
-	/* user might have specified protocol to filter display results */
-	proto_str = cmdenv_get(env, "protocol");
-
-	if (proto_str) {
-		log_debug("display", "filter protocol: %s ", proto_str);
-
-		protocol = 0;
-		for (lldpctl_map_t *protocol_map =
-			 lldpctl_key_get_map(lldpctl_k_port_protocol);
-		     protocol_map->string;
-		     protocol_map++) {
-			if (!strcasecmp(proto_str, protocol_map->string)) {
-				protocol = protocol_map->value;
-				break;
-			}
-		}
-	}
 
 	tag_start(w, "lldp", "LLDP interfaces");
 	while ((iface = cmd_iterate_on_interfaces(conn, env))) {
-		(void)protocol;
 		lldpctl_atom_t *port;
 		port      = lldpctl_get_port(iface);
 		display_interface(conn, w, hidden, iface, port, details, protocol);

--- a/src/client/lldpcli.8.in
+++ b/src/client/lldpcli.8.in
@@ -134,6 +134,26 @@ one or several ports, the information displayed is limited to the
 given list of ports.
 .Ed
 
+.Cd show interfaces
+.Op ports Ar ethX Op ,...
+.Op Cd details | summary
+.Op Cd hidden
+.Bd -ragged -offset XXXXXX
+Display information about each local interface known by
+.Xr lldpd 8
+daemon. With
+.Cd summary ,
+only the name and the port description of each local interface will be
+displayed. On the other hand, with
+.Cd details ,
+all available information will be displayed, giving a verbose
+view. When using
+.Cd hidden ,
+also display local ports hidden by the smart filter. When specifying
+one or several ports, the information displayed is limited to the
+given list of ports.
+.Ed
+
 .Cd show chassis
 .Op Cd details | summary
 .Bd -ragged -offset XXXXXX

--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -1038,6 +1038,7 @@ lldpd_send(struct lldpd_hardware *hardware)
 				    cfg->g_protocols[i].name);
 				cfg->g_protocols[i].send(cfg,
 				    hardware);
+				hardware->h_lport.p_protocol = cfg->g_protocols[i].mode;
 				sent++;
 				break;
 			}

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -45,6 +45,46 @@ def test_several_neighbors(lldpd, lldpcli, links, namespaces, neighbors):
                 'ns-{}.example.com'.format(i)
 
 
+def test_one_interface(lldpd1, lldpd, lldpcli, namespaces):
+    with namespaces(2):
+        lldpd()
+    with namespaces(1):
+        out = lldpcli("-f", "keyvalue", "show", "interfaces")
+        assert out['lldp.eth0.chassis.descr'].startswith(
+            "Spectacular GNU/Linux 2016 Linux")
+        assert 'lldp.eth0.age' in out
+        assert 'lldp.eth0.chassis.Router.enabled' in out
+        assert 'lldp.eth0.chassis.Station.enabled' in out
+        del out['lldp.eth0.age']
+        del out['lldp.eth0.chassis.descr']
+        del out['lldp.eth0.chassis.Router.enabled']
+        del out['lldp.eth0.chassis.Station.enabled']
+        assert out == {"lldp.eth0.via": "unknown",
+                       "lldp.eth0.chassis.mac": "00:00:00:00:00:01",
+                       "lldp.eth0.chassis.name": "ns-1.example.com",
+                       "lldp.eth0.chassis.mgmt-ip": "fe80::200:ff:fe00:1",
+                       "lldp.eth0.chassis.Bridge.enabled": "off",
+                       "lldp.eth0.chassis.Wlan.enabled": "off",
+                       "lldp.eth0.port.mac": "00:00:00:00:00:01",
+                       "lldp.eth0.port.descr": "eth0",
+                       "lldp.eth0.ttl.ttl": "120"}
+
+@pytest.mark.parametrize("interfaces", (5, 10, 20))
+def test_several_interfaces(lldpd, lldpcli, links, namespaces, interfaces):
+    for i in range(2, interfaces + 1):
+        links(namespaces(1), namespaces(i))
+    for i in range(1, interfaces + 1):
+        with namespaces(i):
+            lldpd()
+    with namespaces(1):
+        out = lldpcli("-f", "keyvalue", "show", "interfaces")
+        for i in range(2, interfaces + 1):
+            assert out['lldp.eth{}.chassis.mac'.format((i - 2)*2)] == \
+                '00:00:00:00:00:01'
+            assert out['lldp.eth{}.port.mac'.format((i - 2)*2)] == \
+                '00:00:00:00:00:{num:02x}'.format(num=(i - 2)*2 + 1)
+
+
 def test_overrided_description(lldpd1, lldpd, lldpcli, namespaces):
     with namespaces(2):
         lldpd("-S", "Modified description")


### PR DESCRIPTION
There are several lldpcli configure commands that take port name(s)
as an optional parameter.

Currently, it is not possible to verify interface specific configuration
for lldpd without access to a neighbour switch/host or packet capture.

It would be useful to have a show interfaces command, similar to the
show neighbors command that allows a user/agent to query the local
TLV information.

This commit leverages the existing port display infrastructure to
enable display of local interfaces.  There are a few differences:

- Do not display the chassis RID, as the local index is always 0
- Show TTL as a seperate TLV based on tx_hold, tx_interval config,
  as internally the port TTL atom info is 0, and the chassis TTL
  atom info has been depreciated.