### PR TITLE
daemon: don't use SIGSTOP when using Upstart

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@ lldpd (0.9.9)
       each of them ("show interfaces").
   * Fix:
     + Don't remove interfaces when they are released from a bridge.
+    + Don't use "expect stop" with Upstart. It's buggy.
 
 lldpd (0.9.8)
   * Changes:

--- a/debian/lldpd.upstart
+++ b/debian/lldpd.upstart
@@ -9,7 +9,7 @@ description "LLDP daemon"
 start on net-device-up IFACE=lo
 stop on runlevel [06]
 
-expect stop
+expect fork
 respawn
 
 script

--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -1344,25 +1344,6 @@ static const struct intint filters[] = {
 
 #ifndef HOST_OS_OSX
 /**
- * Tell if we have been started by upstart.
- */
-static int
-lldpd_started_by_upstart()
-{
-#ifdef HOST_OS_LINUX
-	const char *upstartjob = getenv("UPSTART_JOB");
-	if (!(upstartjob && !strcmp(upstartjob, "lldpd")))
-		return 0;
-	log_debug("main", "running with upstart, don't fork but stop");
-	raise(SIGSTOP);
-	unsetenv("UPSTART_JOB");
-	return 1;
-#else
-	return 0;
-#endif
-}
-
-/**
  * Tell if we have been started by systemd.
  */
 static int
@@ -1667,7 +1648,7 @@ lldpd_main(int argc, char *argv[], char *envp[])
 	tzset();		/* Get timezone info before chroot */
 	if (use_syslog && daemonize) {
 		/* So, we use syslog and we daemonize (or we are started by
-		 * upstart/systemd). No need to continue writing to stdout. */
+		 * systemd). No need to continue writing to stdout. */
 		int fd;
 		if ((fd = open("/dev/null", O_RDWR, 0)) != -1) {
 			dup2(fd, STDIN_FILENO);
@@ -1730,10 +1711,10 @@ lldpd_main(int argc, char *argv[], char *envp[])
 	/* Disable SIGHUP, until handlers are installed */
 	signal(SIGHUP, SIG_IGN);
 
-	/* Daemonization, unless started by upstart, systemd or launchd or debug */
+	/* Daemonization, unless started by systemd or launchd or debug */
 #ifndef HOST_OS_OSX
 	if (daemonize &&
-	    !lldpd_started_by_upstart() && !lldpd_started_by_systemd()) {
+	    !lldpd_started_by_systemd()) {
 		int pid;
 		char *spid;
 		log_debug("main", "going into background");


### PR DESCRIPTION
This is buggy because if lldpd happens to stop before sending SIGSTOP,
Upstart won't respawn it. See:
 https://bugs.launchpad.net/upstart/+bug/712351

Instead, let Upstart detects the double fork. This should work just
fine as there is no "trap" before daemonizing.

Fix #245