### PR TITLE
lldpcli: document json0 output format

### DIFF
--- a/src/client/completion/_lldpcli
+++ b/src/client/completion/_lldpcli
@@ -31,7 +31,7 @@ _lldpcli () {
         '*-d[print more debugging information]' \
         '(- *)-v[print version number and exit]' \
         '-u[use an alternate socket with lldpd]:UNIX socket:_files' \
-        '-f[output format]:format:(plain xml json keyvalue)' \
+        '-f[output format]:format:(plain xml json json0 keyvalue)' \
         '*-c[read a configuration file]:configuration file:_files' \
         '(-)*::lldpcli command:__lldpcli_command'
 }

--- a/src/client/lldpcli.c
+++ b/src/client/lldpcli.c
@@ -68,7 +68,7 @@ usage()
 
 	fprintf(stderr, "-d          Enable more debugging information.\n");
 	fprintf(stderr, "-u socket   Specify the Unix-domain socket used for communication with lldpd(8).\n");
-	fprintf(stderr, "-f format   Choose output format (plain, keyvalue, json"
+	fprintf(stderr, "-f format   Choose output format (plain, keyvalue, json, json0"
 #if defined USE_XML
 	    ", xml"
 #endif


### PR DESCRIPTION
Hello,

json0 format has been added but not documented in lldpdcli/lldpdctl help output. PR fixes just that.

Thank you!