### PR TITLE
dot3: as PD device, echo back PSE allocated value

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ lldpd (0.9.9)
   * Changes:
     + lldpcli can now display local interfaces with LLDP data sent on
       each of them ("show interfaces").
+    + As Dot3 PD device, echo back allocated value from PSE device.
   * Fix:
     + Don't remove interfaces when they are released from a bridge.
     + Don't use "expect stop" with Upstart. It's buggy.


### PR DESCRIPTION
Dot3 power TLV contains an allocated value and a requested value. When
PSE allocates some power and says so in its TLV, PD device is expected
to echo back (within 10 seconds) the received value in its own TLV. We
handle this part automatically.

Fix #243
Fix #249