### PR TITLE
LICENSE: add title and copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,7 @@
+The license below applies to most, but not all content in this project.
+Files with different licensing and authorship terms are marked as such.
+That information must be considered when ensuring licensing compliance.
+
 ISC License
 
 Copyright (c) 2008-2017, Vincent Bernat <vincent@bernat.im>

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,7 @@
+ISC License
+
+Copyright (c) 2009, Vincent Bernat <vincent@bernat.im>
+
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
 copyright notice and this permission notice appear in all copies.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2009, Vincent Bernat <vincent@bernat.im>
+Copyright (c) 2008-2017, Vincent Bernat <vincent@bernat.im>
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
The title is not legally mandated, but it's recommended in the license template text (see http://choosealicense.com/licenses/isc/ and https://opensource.org/licenses/isc-license).

The copyright notice is required, IIRC.

*This PR is part of a project to improve the consistency and visibility of the ISC license. See https://github.com/github/choosealicense.com/issues/377 for more details.*