### PR TITLE
configure: remove check on CXX compiler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,6 @@ AC_PROG_CC_C99
 if test x"$ac_cv_prog_cc_c99" = x"no"; then
   AC_MSG_FAILURE([*** C99 support is mandatory])
 fi
-AC_PROG_CXX
 AM_PROG_CC_C_O
 AC_PROG_LIBTOOL
 AC_PROG_LN_S


### PR DESCRIPTION
lldpd fails to build if the toolchain doesn't have a C++ compiler
because configure fails with the following error:

  checking how to run the C++ preprocessor... /lib/cpp
  configure: error: in `/home/dkc/src/buildroot/build-zii/build/lldpd-0.9.4':
  configure: error: C++ preprocessor "/lib/cpp" fails sanity check

Since "8d92800b: build: cleaner way to not alter CFLAGS/CPPFLAGS/LDFLAGS",
it seems that the dependency on C++ is not required anymore, so there
is no reason to keep this restriction. Dropping AC_PROG_CXX allows to
build with a toolchain that doesn't have C++ just fine.