### PR TITLE
build: isolate SNMP-related files during compilation

### DIFF
--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -100,13 +100,6 @@ liblldpd_la_SOURCES += \
 	priv-bsd.c
 endif
 
-# Add SNMP support if needed
-if USE_SNMP
-liblldpd_la_SOURCES += agent.c agent_priv.c agent.h
-liblldpd_la_CFLAGS  += @NETSNMP_CFLAGS@
-lldpd_LDADD         += @NETSNMP_LIBS@
-endif
-
 # seccomp support
 if USE_SECCOMP
 BUILT_SOURCES += syscall-names.h
@@ -121,6 +114,16 @@ nodist_liblldpd_la_SOURCES += syscall-names.h
 liblldpd_la_SOURCES += priv-seccomp.c
 liblldpd_la_CFLAGS  += @SECCOMP_CFLAGS@
 liblldpd_la_LIBADD  += @SECCOMP_LIBS@
+endif
+
+# Add SNMP support if needed
+if USE_SNMP
+noinst_LTLIBRARIES       += liblldpd-snmp.la
+liblldpd_snmp_la_SOURCES  = agent.c agent_priv.c agent.h
+liblldpd_snmp_la_CFLAGS   = $(liblldpd_la_CFLAGS) @NETSNMP_CFLAGS@
+liblldpd_snmp_la_CPPFLAGS = $(liblldpd_la_CPPFLAGS)
+liblldpd_la_LIBADD       += liblldpd-snmp.la
+lldpd_LDADD              += @NETSNMP_LIBS@
 endif
 
 ## Systemtap/DTrace


### PR DESCRIPTION
@NETSNMP_CFLAGS@ is likely to contain some extensively damaged
flags. Ensure we use them only to compile SNMP-related files.

This should fix #231.