### PR TITLE
Fix NULL pointer dereference in lldpd_dot3_power_pd_pse

### DIFF
--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -974,7 +974,7 @@ lldpd_dot3_power_pd_pse(struct lldpd_hardware *hardware)
 		if (!selected_port || port->p_lastupdate > selected_port->p_lastupdate)
 			selected_port = port;
 	}
-	if (selected_port->p_power.allocated != hardware->h_lport.p_power.allocated) {
+	if (selected_port && selected_port->p_power.allocated != hardware->h_lport.p_power.allocated) {
 		log_info("receive", "for %s, PSE told us allocated is now %d instead of %d",
 		    hardware->h_ifname,
 		    selected_port->p_power.allocated,


### PR DESCRIPTION
selected_port might be NULL after the loop if, for example,
no PSE was found among the neighbours.

This fixes a crash that occured with a device connected to
a non-PoE, LLDP-enabled switch via a PoE midspan.