### PR TITLE
handle lldpStatsRemTablesLastChangeTime correctly when items are removed

### DIFF
--- a/src/lldpd-structs.c
+++ b/src/lldpd-structs.c
@@ -176,7 +176,6 @@ lldpd_remote_cleanup(struct lldpd_hardware *hardware,
 		if (!all && expire &&
 		    (now >= port->p_lastupdate + port->p_ttl)) {
 			hardware->h_ageout_cnt++;
-			hardware->h_delete_cnt++;
 			del = 1;
 		}
 		if (del) {
@@ -186,6 +185,10 @@ lldpd_remote_cleanup(struct lldpd_hardware *hardware,
 			 * real list. It is only needed to be called when we
 			 * don't delete the entire list. */
 			if (!all) TAILQ_REMOVE(&hardware->h_rports, port, p_entries);
+
+			hardware->h_delete_cnt++;
+			/* Register last removal to be able to report lldpStatsRemTablesLastChangeTime */
+			hardware->h_lport.p_lastremove = time(NULL);
 			lldpd_port_cleanup(port, 1);
 			free(port);
 		}

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -243,6 +243,8 @@ struct lldpd_port {
 	struct lldpd_chassis	*p_chassis;    /* Attached chassis */
 	time_t			 p_lastchange; /* Time of last change of values */
 	time_t			 p_lastupdate; /* Time of last update received */
+	time_t			 p_lastremove;	/* Time of last removal of a remote port. Used for local ports only
+						 * Used for deciding lldpStatsRemTablesLastChangeTime */
 	struct lldpd_frame	*p_lastframe;  /* Frame received during last update */
 	u_int8_t		 p_protocol;   /* Protocol used to get this port */
 	u_int8_t		 p_hidden_in:1; /* Considered as hidden for reception */


### PR DESCRIPTION
When a port is removed, the time has to be updated. The last removal time is registered per local port, and this timestamp will be used as lldpStatsRemTablesLastChangeTime if it is the latest timestamp.
Also, the lldpStatsRemTablesDeletes is  always increased when an entry in the table is deleted.
