### PR TITLE
Install headers in pkgincludedir in addition to includdir

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,6 +4,7 @@ AM_LDFLAGS = $(LLDP_LDFLAGS)
 
 noinst_LTLIBRARIES = libcommon-daemon-lib.la libcommon-daemon-client.la
 include_HEADERS    = lldp-const.h
+pkginclude_HEADERS    = lldp-const.h
 
 libcommon_daemon_lib_la_SOURCES = \
 	log.c log.h version.c \

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -4,6 +4,7 @@ AM_LDFLAGS = $(LLDP_LDFLAGS)
 
 lib_LTLIBRARIES = liblldpctl.la
 include_HEADERS = lldpctl.h
+pkginclude_HEADERS = lldpctl.h
 
 noinst_LTLIBRARIES = libfixedpoint.la
 libfixedpoint_la_SOURCES = fixedpoint.h fixedpoint.c


### PR DESCRIPTION
I have a use case where I'd like to include lldpd headers, but not everything else in /usr/include. This will install the headers in their own package directory in addition to includedir. Original location is left for backwards compatibility for packages including the headers from the original location.