### PR TITLE
priv: drop most privileges in monitor, only keep CAP_NET_RAW/ADMIN

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,8 +2,8 @@ lldpd (1.0.2)
   * Changes:
     + On Linux, the monitor process will now drop its privileges
       instead of running as root. It will keep CAP_NET_RAW and
-      CAP_NET_ADMIN capabilities. When using SNMP AgentX feature, the
-      access to the socket may require to grant access to _lldpd user.
+      CAP_NET_ADMIN capabilities. When SNMP support is enabled, it may
+      also require CAP_FOWNER.
 
 lldpd (1.0.1)
   * Fix:

--- a/NEWS
+++ b/NEWS
@@ -1,9 +1,8 @@
 lldpd (1.0.2)
   * Changes:
     + On Linux, the monitor process will now drop its privileges
-      instead of running as root. It will keep CAP_NET_RAW and
-      CAP_NET_ADMIN capabilities. When SNMP support is enabled, it may
-      also require CAP_FOWNER.
+      instead of running as root. It will keep CAP_NET_RAW,
+      CAP_NET_ADMIN and CAP_DAC_OVERRIDE capabilities.
 
 lldpd (1.0.1)
   * Fix:

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+lldpd (1.0.2)
+  * Changes:
+    + On Linux, the monitor process will now drop its privileges
+      instead of running as root. It will keep CAP_NET_RAW and
+      CAP_NET_ADMIN capabilities. When using SNMP AgentX feature, the
+      access to the socket may require to grant access to _lldpd user.
+
 lldpd (1.0.1)
   * Fix:
     + Use "mkdir -p" instead of "mkdir" in systemd unit.

--- a/configure.ac
+++ b/configure.ac
@@ -226,6 +226,9 @@ PKG_CHECK_MODULES([check], [check >= 0.9.4], [have_check=yes], [have_check=no])
 
 # Third-party libraries
 lldp_CHECK_LIBEVENT
+PKG_CHECK_MODULES([libcap], [libcap >= 2], [
+  AC_DEFINE([HAVE_LINUX_CAPABILITIES], 1, [Define to indicate support of linux capabilities])
+], [:])
 
 # Compatibility with pkg.m4 < 0.27
 m4_ifdef([PKG_INSTALLDIR], [PKG_INSTALLDIR],

--- a/configure.ac
+++ b/configure.ac
@@ -226,9 +226,7 @@ PKG_CHECK_MODULES([check], [check >= 0.9.4], [have_check=yes], [have_check=no])
 
 # Third-party libraries
 lldp_CHECK_LIBEVENT
-PKG_CHECK_MODULES([libcap], [libcap >= 2], [
-  AC_DEFINE([HAVE_LINUX_CAPABILITIES], 1, [Define to indicate support of linux capabilities])
-], [:])
+lldp_CHECK_LIBCAP
 
 # Compatibility with pkg.m4 < 0.27
 m4_ifdef([PKG_INSTALLDIR], [PKG_INSTALLDIR],

--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Build-Depends: debhelper (>= 5),
                libevent-dev (>= 2.0.5),
                libreadline-dev,
                libbsd-dev,
+               libcap-dev,
                pkg-config,
                lsb-release
 Standards-Version: 3.9.6

--- a/m4/libcap.m4
+++ b/m4/libcap.m4
@@ -1,0 +1,25 @@
+#
+# lldp_CHECK_LIBCAP
+#
+
+AC_DEFUN([lldp_CHECK_LIBCAP], [
+    PKG_CHECK_MODULES([libcap], [libcap >= 2], [
+       AC_DEFINE([HAVE_LINUX_CAPABILITIES], 1, [Define to indicate support of linux capabilities])
+    ], [
+      libcap_LIBS=-lcap
+      libcap_CFLAGS=
+      _save_libs="$LIBS"
+      LIBS="$LIBS ${libcap_LIBS}"
+      AC_MSG_CHECKING([libcap (without pkg-config)])
+      AC_TRY_LINK_FUNC([cap_set_proc], [
+         AC_DEFINE([HAVE_LINUX_CAPABILITIES], 1, [Define to indicate support of linux capabilities])
+         AC_MSG_RESULT(yes)
+      ], [
+         libcap_LIBS=
+         AC_MSG_RESULT(no)
+      ])
+      LIBS="$_save_libs"
+    ])
+    AC_SUBST([libcap_LIBS])
+    AC_SUBST([libcap_CFLAGS])
+])

--- a/redhat/lldpd.spec
+++ b/redhat/lldpd.spec
@@ -58,6 +58,7 @@ BuildRequires: pkgconfig
 BuildRequires: libevent-devel
 %endif
 BuildRequires: readline-devel
+BuildRequires: libcap-devel
 %if %{with snmp}
 BuildRequires: net-snmp-devel
 BuildRequires: openssl-devel

--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -28,11 +28,11 @@ liblldpd_la_SOURCES  = \
 	protocols/sonmp.h \
 	protocols/edp.c \
 	protocols/edp.h
-liblldpd_la_CFLAGS   = $(AM_CFLAGS) @libevent_CFLAGS@
+liblldpd_la_CFLAGS   = $(AM_CFLAGS) @libevent_CFLAGS@ @libcap_CFLAGS@
 liblldpd_la_CPPFLAGS = $(AM_CPPFLAGS) -DSYSCONFDIR='"$(sysconfdir)"' -DLLDPCLI_PATH='"$(sbindir)/lldpcli"'
 liblldpd_la_LIBADD   = \
 	$(top_builddir)/src/libcommon-daemon-client.la \
-	$(top_builddir)/src/libcommon-daemon-lib.la @libevent_LIBS@
+	$(top_builddir)/src/libcommon-daemon-lib.la @libevent_LIBS@ @libcap_LIBS@
 
 ## lldpd
 lldpd_SOURCES = main.c

--- a/src/daemon/agent_priv.c
+++ b/src/daemon/agent_priv.c
@@ -222,6 +222,12 @@ agent_priv_unix_create_ostring(const u_char * o, size_t o_len, int local)
 	return agent_priv_unix_transport((char *)o, o_len, local);
 }
 
+const char *
+agent_default_agentx_socket()
+{
+	return NETSNMP_AGENTX_SOCKET;
+}
+
 void
 agent_priv_register_domain()
 {

--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -1827,7 +1827,7 @@ lldpd_main(int argc, char *argv[], char *envp[])
 #ifdef ENABLE_PRIVSEP
 	priv_init(PRIVSEP_CHROOT, ctl, uid, gid,
 #ifdef USE_SNMP
-	    (agentx ? agentx : agent_default_agentx_socket())[0] == '/'
+	    snmp && ((agentx ? agentx : agent_default_agentx_socket())[0] == '/')
 #else
 	    0
 #endif

--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -1825,15 +1825,9 @@ lldpd_main(int argc, char *argv[], char *envp[])
 
 	log_debug("main", "initialize privilege separation");
 #ifdef ENABLE_PRIVSEP
-	priv_init(PRIVSEP_CHROOT, ctl, uid, gid,
-#ifdef USE_SNMP
-	    snmp && ((agentx ? agentx : agent_default_agentx_socket())[0] == '/')
+	priv_init(PRIVSEP_CHROOT, ctl, uid, gid);
 #else
-	    0
-#endif
-	);
-#else
-	priv_init(PRIVSEP_CHROOT, ctl, 0, 0, 0);
+	priv_init(PRIVSEP_CHROOT, ctl, 0, 0);
 #endif
 
 	/* Initialization of global configuration */

--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -1825,9 +1825,15 @@ lldpd_main(int argc, char *argv[], char *envp[])
 
 	log_debug("main", "initialize privilege separation");
 #ifdef ENABLE_PRIVSEP
-	priv_init(PRIVSEP_CHROOT, ctl, uid, gid);
+	priv_init(PRIVSEP_CHROOT, ctl, uid, gid,
+#ifdef USE_SNMP
+	    (agentx ? agentx : agent_default_agentx_socket())[0] == '/'
 #else
-	priv_init(PRIVSEP_CHROOT, ctl, 0, 0);
+	    0
+#endif
+	);
+#else
+	priv_init(PRIVSEP_CHROOT, ctl, 0, 0, 0);
 #endif
 
 	/* Initialization of global configuration */

--- a/src/daemon/lldpd.h
+++ b/src/daemon/lldpd.h
@@ -179,6 +179,7 @@ void		 agent_notify(struct lldpd_hardware *, int, struct lldpd_port *);
 #ifdef ENABLE_PRIVSEP
 /* agent_priv.c */
 void		 agent_priv_register_domain(void);
+const char	*agent_default_agentx_socket(void);
 #endif
 
 /* client.c */
@@ -190,7 +191,7 @@ client_handle_client(struct lldpd *cfg,
     int*);
 
 /* priv.c */
-void	 priv_init(const char*, int, uid_t, gid_t);
+void	 priv_init(const char*, int, uid_t, gid_t, int);
 void	 priv_wait(void);
 void	 priv_ctl_cleanup(const char *ctlname);
 char   	*priv_gethostname(void);

--- a/src/daemon/lldpd.h
+++ b/src/daemon/lldpd.h
@@ -191,7 +191,7 @@ client_handle_client(struct lldpd *cfg,
     int*);
 
 /* priv.c */
-void	 priv_init(const char*, int, uid_t, gid_t, int);
+void	 priv_init(const char*, int, uid_t, gid_t);
 void	 priv_wait(void);
 void	 priv_ctl_cleanup(const char *ctlname);
 char   	*priv_gethostname(void);

--- a/src/daemon/priv-linux.c
+++ b/src/daemon/priv-linux.c
@@ -188,8 +188,8 @@ asroot_iface_description_os(const char *name, const char *description)
 	}
 	if ((fp = fopen(file, "r+")) == NULL) {
 		rc = errno;
-		log_debug("privsep", "cannot open interface description for %s: %m",
-		    name);
+		log_debug("privsep", "cannot open interface description for %s: %s",
+		    name, strerror(errno));
 		free(file);
 		return rc;
 	}

--- a/src/daemon/priv-linux.c
+++ b/src/daemon/priv-linux.c
@@ -188,9 +188,9 @@ asroot_iface_description_os(const char *name, const char *description)
 	}
 	if ((fp = fopen(file, "r+")) == NULL) {
 		rc = errno;
-		free(file);
-		log_debug("privsep", "cannot open interface description for %s",
+		log_debug("privsep", "cannot open interface description for %s: %m",
 		    name);
+		free(file);
 		return rc;
 	}
 	free(file);

--- a/src/daemon/priv.c
+++ b/src/daemon/priv.c
@@ -625,20 +625,15 @@ priv_drop(uid_t uid, gid_t gid)
 }
 
 void
-priv_caps(uid_t uid, gid_t gid, int fowner)
+priv_caps(uid_t uid, gid_t gid)
 {
 #ifdef HAVE_LINUX_CAPABILITIES
 	cap_t caps;
-	const char *caps_strings[2];
-	if (fowner) {
-		log_debug("privsep", "getting CAP_NET_RAW/ADMIN and CAP_FOWNER privilege");
-		caps_strings[0] = "cap_fowner,cap_net_raw,cap_net_admin,cap_setuid,cap_setgid=pe";
-		caps_strings[1] = "cap_fowner,cap_net_raw,cap_net_admin=pe";
-	} else {
-		log_debug("privsep", "getting CAP_NET_RAW/ADMIN privilege");
-		caps_strings[0] = "cap_net_raw,cap_net_admin,cap_setuid,cap_setgid=pe";
-		caps_strings[1] = "cap_net_raw,cap_net_admin=pe";
-	}
+	const char *caps_strings[2] = {
+		"cap_fowner,cap_net_raw,cap_net_admin,cap_setuid,cap_setgid=pe",
+		"cap_fowner,cap_net_raw,cap_net_admin=pe"
+	};
+	log_debug("privsep", "getting CAP_NET_RAW/ADMIN and CAP_FOWNER privilege");
 	if (!(caps = cap_from_text(caps_strings[0])))
 		fatal("privsep", "unable to convert caps");
 	if (cap_set_proc(caps) == -1) {
@@ -664,7 +659,7 @@ priv_caps(uid_t uid, gid_t gid, int fowner)
 }
 
 void
-priv_init(const char *chrootdir, int ctl, uid_t uid, gid_t gid, int fowner)
+priv_init(const char *chrootdir, int ctl, uid_t uid, gid_t gid)
 {
 
 	int pair[2];
@@ -705,7 +700,7 @@ priv_init(const char *chrootdir, int ctl, uid_t uid, gid_t gid, int fowner)
 		if (atexit(priv_exit) != 0)
 			fatal("privsep", "unable to set exit function");
 
-		priv_caps(uid, gid, fowner);
+		priv_caps(uid, gid);
 
 		/* Install signal handlers */
 		const struct sigaction pass_to_child = {

--- a/src/daemon/priv.c
+++ b/src/daemon/priv.c
@@ -37,6 +37,11 @@
 #include <sys/ioctl.h>
 #include <netinet/if_ether.h>
 
+#ifdef HAVE_LINUX_CAPABILITIES
+#include <sys/capability.h>
+#include <sys/prctl.h>
+#endif
+
 #if defined HOST_OS_FREEBSD || HOST_OS_OSX || HOST_OS_DRAGONFLY
 # include <net/if_dl.h>
 #endif
@@ -596,6 +601,60 @@ sig_chld(int sig)
 #endif
 
 void
+priv_drop(uid_t uid, gid_t gid)
+{
+	gid_t gidset[1];
+	gidset[0] = gid;
+	log_debug("privsep", "dropping privileges");
+#ifdef HAVE_SETRESGID
+	if (setresgid(gid, gid, gid) == -1)
+		fatal("privsep", "setresgid() failed");
+#else
+	if (setregid(gid, gid) == -1)
+		fatal("privsep", "setregid() failed");
+#endif
+	if (setgroups(1, gidset) == -1)
+		fatal("privsep", "setgroups() failed");
+#ifdef HAVE_SETRESUID
+	if (setresuid(uid, uid, uid) == -1)
+		fatal("privsep", "setresuid() failed");
+#else
+	if (setreuid(uid, uid) == -1)
+		fatal("privsep", "setreuid() failed");
+#endif
+}
+
+void
+priv_caps(uid_t uid, gid_t gid)
+{
+#ifdef HAVE_LINUX_CAPABILITIES
+	cap_t caps;
+	log_debug("privsep", "getting CAP_NET_RAW/ADMIN privilege");
+	if (!(caps = cap_from_text("cap_net_raw,cap_net_admin,cap_setuid,cap_setgid=pe")))
+		fatal("privsep", "unable to convert caps");
+	if (cap_set_proc(caps) == -1) {
+		log_warn("privsep", "unable to drop privileges, monitor running as root");
+		cap_free(caps);
+		return;
+	}
+	cap_free(caps);
+
+	if (prctl(PR_SET_KEEPCAPS, 1L, 0L, 0L, 0L) == -1)
+		fatal("privsep", "cannot keep capabilities");
+	priv_drop(uid, gid);
+
+	log_debug("privsep", "dropping extra capabilities");
+	if (!(caps = cap_from_text("cap_net_raw,cap_net_admin=pe")))
+		fatal("privsep", "unable to convert caps");
+	if (cap_set_proc(caps) == -1)
+		fatal("privsep", "unable to drop extra privileges");
+	cap_free(caps);
+#else
+	log_info("privsep", "no libcap support, running monitor as root");
+#endif
+}
+
+void
 priv_init(const char *chrootdir, int ctl, uid_t uid, gid_t gid)
 {
 
@@ -611,7 +670,6 @@ priv_init(const char *chrootdir, int ctl, uid_t uid, gid_t gid)
 	priv_privileged_fd(pair[1]);
 
 #ifdef ENABLE_PRIVSEP
-	gid_t gidset[1];
 	/* Spawn off monitor */
 	if ((monitored = fork()) < 0)
 		fatal("privsep", "unable to fork monitor");
@@ -626,23 +684,7 @@ priv_init(const char *chrootdir, int ctl, uid_t uid, gid_t gid)
 				fatal("privsep", "unable to chroot");
 			if (chdir("/") != 0)
 				fatal("privsep", "unable to chdir");
-			gidset[0] = gid;
-#ifdef HAVE_SETRESGID
-			if (setresgid(gid, gid, gid) == -1)
-				fatal("privsep", "setresgid() failed");
-#else
-			if (setregid(gid, gid) == -1)
-				fatal("privsep", "setregid() failed");
-#endif
-			if (setgroups(1, gidset) == -1)
-				fatal("privsep", "setgroups() failed");
-#ifdef HAVE_SETRESUID
-			if (setresuid(uid, uid, uid) == -1)
-				fatal("privsep", "setresuid() failed");
-#else
-			if (setreuid(uid, uid) == -1)
-				fatal("privsep", "setreuid() failed");
-#endif
+			priv_drop(uid, gid);
 		}
 		close(pair[1]);
 		priv_ping();
@@ -653,6 +695,8 @@ priv_init(const char *chrootdir, int ctl, uid_t uid, gid_t gid)
 		close(pair[0]);
 		if (atexit(priv_exit) != 0)
 			fatal("privsep", "unable to set exit function");
+
+		priv_caps(uid, gid);
 
 		/* Install signal handlers */
 		const struct sigaction pass_to_child = {

--- a/src/daemon/priv.c
+++ b/src/daemon/priv.c
@@ -630,10 +630,10 @@ priv_caps(uid_t uid, gid_t gid)
 #ifdef HAVE_LINUX_CAPABILITIES
 	cap_t caps;
 	const char *caps_strings[2] = {
-		"cap_fowner,cap_net_raw,cap_net_admin,cap_setuid,cap_setgid=pe",
-		"cap_fowner,cap_net_raw,cap_net_admin=pe"
+		"cap_dac_override,cap_net_raw,cap_net_admin,cap_setuid,cap_setgid=pe",
+		"cap_dac_override,cap_net_raw,cap_net_admin=pe"
 	};
-	log_debug("privsep", "getting CAP_NET_RAW/ADMIN and CAP_FOWNER privilege");
+	log_debug("privsep", "getting CAP_NET_RAW/ADMIN and CAP_DAC_OVERRIDE privilege");
 	if (!(caps = cap_from_text(caps_strings[0])))
 		fatal("privsep", "unable to convert caps");
 	if (cap_set_proc(caps) == -1) {

--- a/tests/ci/install.sh
+++ b/tests/ci/install.sh
@@ -20,7 +20,8 @@ case "$(uname -s)" in
             libsnmp-dev libxml2-dev \
             libevent-dev libreadline-dev libbsd-dev \
             check libc6-dbg libevent-dbg libseccomp-dev \
-            libpcap-dev libcap-dev
+            libpcap-dev libcap-dev \
+            snmpd snmp
         [ $CC != gcc ] || \
             sudo apt-get -qqy install gcc-5
         # For integration tests

--- a/tests/ci/install.sh
+++ b/tests/ci/install.sh
@@ -20,7 +20,7 @@ case "$(uname -s)" in
             libsnmp-dev libxml2-dev \
             libevent-dev libreadline-dev libbsd-dev \
             check libc6-dbg libevent-dbg libseccomp-dev \
-            libpcap-dev
+            libpcap-dev libcap-dev
         [ $CC != gcc ] || \
             sudo apt-get -qqy install gcc-5
         # For integration tests

--- a/tests/integration/fixtures/namespaces.py
+++ b/tests/integration/fixtures/namespaces.py
@@ -5,6 +5,7 @@ import os
 import pyroute2
 import pytest
 import signal
+import multiprocessing
 
 # All allowed namespace types
 NAMESPACE_FLAGS = dict(mnt=0x00020000,
@@ -41,6 +42,47 @@ def mount_sys(target="/sys"):
         if ret == -1:
             e = ctypes.get_errno()
             raise OSError(e, os.strerror(e))
+
+
+def mount_tmpfs(target, private=False):
+    flags = [0]
+    if private:
+        flags.append(1 << 18)   # MS_PRIVATE
+        flags.append(1 << 19)   # MS_SLAVE
+    for fl in flags:
+        ret = libc.mount(b"none",
+                         target.encode('ascii'),
+                         b"tmpfs",
+                         fl,
+                         None)
+        if ret == -1:
+            e = ctypes.get_errno()
+            raise OSError(e, os.strerror(e))
+
+
+def _mount_proc(target):
+    flags = [2 | 4 | 8] # MS_NOSUID | MS_NODEV | MS_NOEXEC
+    flags.append(1 << 18)   # MS_PRIVATE
+    flags.append(1 << 19)   # MS_SLAVE
+    for fl in flags:
+        ret = libc.mount(b"proc",
+                         target.encode('ascii'),
+                         b"proc",
+                         fl,
+                         None)
+        if ret == -1:
+            e = ctypes.get_errno()
+            raise OSError(e, os.strerror(e))
+
+
+def mount_proc(target="/proc"):
+    # We need to be sure /proc is correct. We do that in another
+    # process as this doesn't play well with setns().
+    if not os.path.isdir(target):
+        os.mkdir(target)
+    p = multiprocessing.Process(target=_mount_proc, args=(target,))
+    p.start()
+    p.join()
 
 
 class Namespace(object):
@@ -127,7 +169,6 @@ class Namespace(object):
                        # MS_REC | MS_PRIVATE
                        16384 | (1 << 18),
                        None)
-            mount_sys()
 
         while True:
             try:
@@ -179,17 +220,26 @@ class NamespaceFactory(object):
 
     """
 
-    def __init__(self):
+    def __init__(self, tmpdir):
         self.namespaces = {}
+        self.tmpdir = tmpdir
 
     def __call__(self, ns):
         """Return a namespace. Create it if it doesn't exist."""
         if ns in self.namespaces:
             return self.namespaces[ns]
+
         self.namespaces[ns] = Namespace('ipc', 'net', 'mnt', 'uts')
+        with self.namespaces[ns]:
+            mount_proc()
+            mount_sys()
+            # Also setup the "namespace-dependant" directory
+            self.tmpdir.join("ns").ensure(dir=True)
+            mount_tmpfs(str(self.tmpdir.join("ns")), private=True)
+
         return self.namespaces[ns]
 
 
 @pytest.fixture
-def namespaces():
-    return NamespaceFactory()
+def namespaces(tmpdir):
+    return NamespaceFactory(tmpdir)

--- a/tests/integration/fixtures/namespaces.py
+++ b/tests/integration/fixtures/namespaces.py
@@ -28,6 +28,21 @@ def keep_directory():
         os.chdir(pwd)
 
 
+def mount_sys(target="/sys"):
+    flags = [2 | 4 | 8] # MS_NOSUID | MS_NODEV | MS_NOEXEC
+    flags.append(1 << 18)   # MS_PRIVATE
+    flags.append(1 << 19)   # MS_SLAVE
+    for fl in flags:
+        ret = libc.mount(b"none",
+                         target.encode('ascii'),
+                         b"sysfs",
+                         fl,
+                         None)
+        if ret == -1:
+            e = ctypes.get_errno()
+            raise OSError(e, os.strerror(e))
+
+
 class Namespace(object):
     """Combine several namespaces into one.
 
@@ -112,6 +127,7 @@ class Namespace(object):
                        # MS_REC | MS_PRIVATE
                        16384 | (1 << 18),
                        None)
+            mount_sys()
 
         while True:
             try:

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -260,7 +260,6 @@ def test_portid_subtype_local_with_alias(lldpd1, lldpd, lldpcli, namespaces):
         idx = ipr.link_lookup(ifname="eth1")[0]
         ipr.link('set', index=idx, ifalias="alias of eth1")
         lldpd()
-        lldpd()
         lldpcli("configure", "lldp", "portidsubtype", "local", "localname")
         time.sleep(3)
     with namespaces(1):

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -333,3 +333,12 @@ def test_port_status_disabled(lldpd, lldpcli, namespaces, links):
         assert out == {}
 
 
+def test_set_interface_alias(lldpd1, lldpd, lldpcli, namespaces):
+    with namespaces(1):
+        lldpcli("configure", "system", "interface", "description")
+    with namespaces(2):
+        lldpd()
+    with namespaces(1):
+        ipr = pyroute2.IPRoute()
+        link = ipr.link('get', ifname='eth0')[0]
+        assert link.get_attr('IFLA_IFALIAS') == 'lldpd: connected to ns-2.example.com'

--- a/tests/integration/test_snmp.py
+++ b/tests/integration/test_snmp.py
@@ -1,0 +1,29 @@
+import pytest
+import time
+
+pytestmark = pytest.mark.skipif(not pytest.config.lldpd.snmp,
+                                reason="no SNMP support")
+
+
+def test_snmp_register(snmpd, snmpwalk, lldpd, namespaces):
+    with namespaces(1):
+        snmpd()
+        lldpd("-x")
+        out = snmpwalk(".1.3.6.1.2.1.1.9.1.3")
+        assert 'STRING: "lldpMIB implementation by lldpd"' in out.values()
+
+
+def test_snmp_one_neighbor(snmpd, snmpwalk, lldpd, namespaces):
+    with namespaces(1):
+        snmpd()
+        lldpd("-x")
+    with namespaces(2):
+        lldpd()
+    with namespaces(1):
+        out = snmpwalk(".1.0.8802.1.1.2.1")
+        assert out['.1.0.8802.1.1.2.1.2.1.0'].startswith(
+            "Timeticks: ")
+        assert out['.1.0.8802.1.1.2.1.3.2.0'] == 'STRING: "ns-1.example.com"'
+        assert out['.1.0.8802.1.1.2.1.3.3.0'] == 'STRING: "ns-1.example.com"'
+        assert out['.1.0.8802.1.1.2.1.3.4.0'].startswith(
+            'STRING: "Spectacular GNU/Linux 2016 Linux')


### PR DESCRIPTION
On Linux, we mostly rely on CAP_NET_RAW. Only keep that one. However,
we also write to ifalias, which needs CAP_NET_ADMIN. We could let user
choose at runtime if they want to grant this capability or not.
Currently, a user can turn it on/off at any time.

Access to SNMP socket may also be problematic. We need some solid
solution about that before merging.

Is it safe to use the same UID for the monitored and the unprivileged
process? Signals are mostly harmless. As for ptrace, since the
monitored process as more capabilities, this will not be allowed by
Linux.