### PR TITLE
Read all notifications in lldpctl_recv.

### DIFF
--- a/src/lib/connection.c
+++ b/src/lib/connection.c
@@ -253,8 +253,8 @@ lldpctl_recv(lldpctl_conn_t *conn, const uint8_t *data, size_t length)
 	memcpy(conn->input_buffer + conn->input_buffer_len, data, length);
 	conn->input_buffer_len += length;
 
-	/* Is it a notification? */
-	check_for_notification(conn);
+	/* Read all notifications */
+	while(!check_for_notification(conn));
 
 	RESET_ERROR(conn);
 


### PR DESCRIPTION
Can otherwise lead to unbounded growth in input_buffer if
lldp devices send notifications simultaneously thus
a socket callback contains multiple notifications
and only the first one is cleared. This leads to continous
growth of the input buffer and will crash the system.