### PR TITLE
Add support to disable MED policy from port.

### DIFF
--- a/src/client/conf-med.c
+++ b/src/client/conf-med.c
@@ -191,6 +191,9 @@ cmd_medpolicy(struct lldpctl_conn_t *conn, struct writer *w,
 		    (what = "tagged flag", lldpctl_atom_set_int(med_policy,
 			lldpctl_k_med_policy_tagged,
 			cmdenv_get(env, "tagged")?1:0)) == NULL ||
+		    (what = "disabled flag", lldpctl_atom_set_int(med_policy,
+			lldpctl_k_med_policy_disabled,
+			cmdenv_get(env, "disabled")?1:0)) == NULL ||
 		    (what = "vlan",
 			cmdenv_get(env, "vlan")?
 			lldpctl_atom_set_str(med_policy,
@@ -433,6 +436,11 @@ register_commands_medpol(struct cmd_node *configure_med)
 		configure_medpolicy,
 		"tagged", "Set tagged flag",
 		cmd_check_application_but_no, cmd_store_env_and_pop, "tagged");
+	commands_new(
+		configure_medpolicy,
+		"disabled", "Disable policy from port",
+		cmd_check_application_but_no, cmd_store_env_and_pop, "disabled");
+
 	commands_new(
 		commands_new(
 			configure_medpolicy,

--- a/src/daemon/protocols/lldp.c
+++ b/src/daemon/protocols/lldp.c
@@ -385,7 +385,8 @@ static int _lldp_send(struct lldpd *global,
 
 		/* LLDP-MED network policy */
 		for (i = 0; i < LLDP_MED_APPTYPE_LAST; i++) {
-			if (port->p_med_policy[i].type == i + 1) {
+			if (port->p_med_policy[i].type == i + 1 &&
+          		    port->p_med_policy[i].disabled == 0) {
 				if (!(
 				      POKE_START_LLDP_TLV(LLDP_TLV_ORG) &&
 				      POKE_BYTES(med, sizeof(med)) &&

--- a/src/lib/atoms/med.c
+++ b/src/lib/atoms/med.c
@@ -213,6 +213,8 @@ _lldpctl_atom_get_int_med_policy(lldpctl_atom_t *atom, lldpctl_key_t key)
 		return m->policy->dscp;
 	case lldpctl_k_med_policy_priority:
 		return m->policy->priority;
+  	case lldpctl_k_med_policy_disabled:
+    		return m->policy->disabled;
 	default:
 		return SET_ERROR(atom->conn, LLDPCTL_ERR_NOT_EXIST);
 	}
@@ -260,6 +262,10 @@ _lldpctl_atom_set_int_med_policy(lldpctl_atom_t *atom, lldpctl_key_t key,
 		if (value < 0 || value > 7) goto bad;
 		m->policy->priority = value;
 		return atom;
+  	case lldpctl_k_med_policy_disabled:
+		if (value != 0 && value != 1) goto bad;
+    		m->policy->disabled = value;
+    		return atom;
 	default:
 		SET_ERROR(atom->conn, LLDPCTL_ERR_NOT_EXIST);
 		return NULL;

--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -750,6 +750,7 @@ typedef enum {
 	lldpctl_k_med_policy_vid,    /**< `(I,W)` MED policy VID */
 	lldpctl_k_med_policy_priority, /**< `(I,W)` MED policy priority */
 	lldpctl_k_med_policy_dscp,     /**< `(I,W)` MED policy DSCP */
+	lldpctl_k_med_policy_disabled,     /**< `(I,W)` MED policy enabled/disabled */
 
 	lldpctl_k_port_med_locations = 2100, /**< `(AL,WO)` MED locations attached to a port. */
 	lldpctl_k_med_location_format, /**< `(IS,W)` MED location format. See

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -82,6 +82,7 @@ struct lldpd_med_policy {
 	u_int16_t		 vid;
 	u_int8_t		 priority;
 	u_int8_t		 dscp;
+  	u_int8_t     		 disabled; /* 1 = disabled, 0 = enabled */
 };
 MARSHAL(lldpd_med_policy);
 


### PR DESCRIPTION
Before it was possible to enable/modify network policy TLVs on a port
but it was not possible to disable them[1].

This commit introduces a new command in the form `configure ports <port>
med policy application <app> disabled` to explicitly disable an
application TLV from a port.

[1] https://github.com/vincentbernat/lldpd/issues/292