### PR TITLE
daemon: do not explicitely inline functions

### DIFF
--- a/src/daemon/agent.c
+++ b/src/daemon/agent.c
@@ -38,7 +38,7 @@ extern int unregister_sysORTable(oid *, size_t);
 #define scfg agent_scfg
 struct lldpd *agent_scfg;
 
-static inline uint8_t
+static uint8_t
 swap_bits(uint8_t n)
 {
   n = ((n&0xF0) >>4 ) | ( (n&0x0F) <<4);

--- a/src/daemon/interfaces-linux.c
+++ b/src/daemon/interfaces-linux.c
@@ -446,21 +446,21 @@ struct ethtool_link_usettings {
 	} link_modes;
 };
 
-static inline int
+static int
 iflinux_ethtool_link_mode_test_bit(unsigned int nr, const uint32_t *mask)
 {
 	if (nr >= 32 * ETHTOOL_LINK_MODE_MASK_MAX_KERNEL_NU32)
 		return 0;
 	return !!(mask[nr / 32] & (1 << (nr % 32)));
 }
-static inline void
+static void
 iflinux_ethtool_link_mode_unset_bit(unsigned int nr, uint32_t *mask)
 {
 	if (nr >= 32 * ETHTOOL_LINK_MODE_MASK_MAX_KERNEL_NU32)
 		return;
 	mask[nr / 32] &= ~(1 << (nr % 32));
 }
-static inline int
+static int
 iflinux_ethtool_link_mode_is_empty(const uint32_t *mask)
 {
 	for (unsigned int i = 0;

--- a/src/daemon/interfaces.c
+++ b/src/daemon/interfaces.c
@@ -24,6 +24,17 @@
 #include <assert.h>
 #include <arpa/inet.h>
 
+static int
+lldpd_af(int af)
+{
+	switch (af) {
+	case LLDPD_AF_IPV4: return AF_INET;
+	case LLDPD_AF_IPV6: return AF_INET6;
+	case LLDPD_AF_LAST: return AF_MAX;
+	default: return AF_UNSPEC;
+	}
+}
+
 /* Generic ethernet interface initialization */
 /**
  * Enable multicast on the given interface.

--- a/src/daemon/protocols/lldp.c
+++ b/src/daemon/protocols/lldp.c
@@ -25,7 +25,7 @@
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 
-inline static int
+static int
 lldpd_af_to_lldp_proto(int af)
 {
 	switch (af) {
@@ -38,7 +38,7 @@ lldpd_af_to_lldp_proto(int af)
 	}
 }
 
-inline static int
+static int
 lldpd_af_from_lldp_proto(int proto)
 {
 	switch (proto) {

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -143,17 +143,6 @@ enum {
 	LLDPD_AF_LAST
 };
 
-inline static int
-lldpd_af(int af)
-{
-	switch (af) {
-	case LLDPD_AF_IPV4: return AF_INET;
-	case LLDPD_AF_IPV6: return AF_INET6;
-	case LLDPD_AF_LAST: return AF_MAX;
-	default: return AF_UNSPEC;
-	}
-}
-
 #define LLDPD_MGMT_MAXADDRSIZE	16 /* sizeof(struct in6_addr) */
 union lldpd_address {
 	struct in_addr		inet;


### PR DESCRIPTION
As we are using `-Winline`, if it fails, we get a warning. Let the
compiler decide if something has to be inlined. As we use only static
functions, it should be easy to inline if possible.