### PR TITLE
Allow linux kernel to autoprobe correct socket_nl.nl_pid address

### DIFF
--- a/src/daemon/netlink.c
+++ b/src/daemon/netlink.c
@@ -93,7 +93,7 @@ netlink_connect(struct lldpd *cfg, int protocol, unsigned groups)
 	int s;
 	struct sockaddr_nl local = {
 		.nl_family = AF_NETLINK,
-		.nl_pid = getpid(),
+		.nl_pid = 0,
 		.nl_groups = groups
 	};
 


### PR DESCRIPTION
In SONiC project we found https://github.com/Azure/sonic-buildimage/pull/2164 that if lldpd is running inside of the docker container its netlink socket  could conflict with another running process which has the same pid.
lldpd uses pid as socket_nl.nl_pid address. But as soon as we have another process with the netlink socket in another docker container with the same pid, it will prevent lldpd from starting with the message:
`lldpd[24]: unable to bind netlink socket: Address already in use`
This is because netlink sockets are global, they don't support Linux namespaces, so if we use get_pid() to fill  nl_pid it could cause an issue: "Address already in use".

But if we use 0 as .nl_pid address kernel will try to find nl_pid address by itself.
From man 7 netlink:
```
       nl_pid is the unicast address of netlink socket.  It's always 0 if
       the destination is in the kernel.  For a user-space process, nl_pid
       is usually the PID of the process owning the destination socket.
       However, nl_pid identifies a netlink socket, not a process.  If a
       process owns several netlink sockets, then nl_pid can be equal to the
       process ID only for at most one socket.  There are two ways to assign
       nl_pid to a netlink socket.  If the application sets nl_pid before
       calling bind(2), then it is up to the application to make sure that
       nl_pid is unique.  If the application sets it to 0, the kernel takes
       care of assigning it.  The kernel assigns the process ID to the first
       netlink socket the process opens and assigns a unique nl_pid to every
       netlink socket that the process subsequently creates.
```
