### PR TITLE
interfaces: remove specific handling for bonds except with --enable-o…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,9 @@ lldpd (1.0.2)
       CAP_NET_ADMIN and CAP_DAC_OVERRIDE capabilities.
     + Support for CDP PD PoE (with negotiation). Thanks to Gustav
       Wiklander.
+    + Move support for bonded devices on Linux < 2.6.27 into the
+      `--enable-oldies` option. This avoids duplicate packets
+      starting from Linux 4.19.
 
 lldpd (1.0.1)
   * Fix:

--- a/src/daemon/interfaces-linux.c
+++ b/src/daemon/interfaces-linux.c
@@ -671,6 +671,7 @@ iflinux_macphy(struct lldpd *cfg, struct lldpd_hardware *hardware)
 #endif /* ENABLE_DOT3 */
 
 
+#ifdef ENABLE_OLDIES
 struct bond_master {
 	char name[IFNAMSIZ];
 	int  index;
@@ -847,6 +848,7 @@ iflinux_handle_bond(struct lldpd *cfg, struct interfaces_device_list *interfaces
 		hardware->h_mtu = iface->mtu ? iface->mtu : 1500;
 	}
 }
+#endif
 
 /* Query each interface to get the appropriate driver */
 static void
@@ -1032,7 +1034,9 @@ interfaces_update(struct lldpd *cfg)
 	iflinux_add_physical(cfg, interfaces);
 
 	interfaces_helper_whitelist(cfg, interfaces);
+#ifdef ENABLE_OLDIES
 	iflinux_handle_bond(cfg, interfaces);
+#endif
 	interfaces_helper_physical(cfg, interfaces,
 	    &eth_ops,
 	    iflinux_eth_init);


### PR DESCRIPTION
…ldies

Starting from Linux 4.19, LLDP packets are transmitted back to the
bond devices and it seems the original interface is lost in the
process. Therefore, packets are duplicated to both members. Upstream
commit is:

    commit 6a9e461f6fe4434e6172304b69774daff9a3ac4c
    Author: Mahesh Bandewar <maheshb@google.com>
    Date:   Mon Sep 24 14:39:42 2018 -0700

    bonding: pass link-local packets to bonding master also.

    Commit b89f04c61efe ("bonding: deliver link-local packets with
    skb->dev set to link that packets arrived on") changed the behavior
    of how link-local-multicast packets are processed. The change in
    the behavior broke some legacy use cases where these packets are
    expected to arrive on bonding master device also.

    This patch passes the packet to the stack with the link it arrived
    on as well as passes to the bonding-master device to preserve the
    legacy use case.

    Fixes: b89f04c61efe ("bonding: deliver link-local packets with skb->dev set to link that packets arrived on")
    Reported-by: Michal Soltys <soltys@ziu.info>
    Signed-off-by: Mahesh Bandewar <maheshb@google.com>
    Signed-off-by: David S. Miller <davem@davemloft.net>

The code to handle bond devices is not needed since Linux 2.6.27.
Therefore, move it to the `--enable-oldies` option.

Fix #306.