### PR TITLE
interfaces/linux: make dsa special

### DIFF
--- a/src/daemon/interfaces-linux.c
+++ b/src/daemon/interfaces-linux.c
@@ -994,7 +994,7 @@ iflinux_add_physical(struct lldpd *cfg,
 		}
 
 		/* If the interface is linked to another one, skip it too. */
-		if (iface->lower && (!iface->driver || strcmp(iface->driver, "veth"))) {
+		if (iface->lower && (!iface->driver || (strcmp(iface->driver, "veth") && strcmp(iface->driver, "dsa")))) {
 			log_debug("interfaces", "skip %s: there is a lower interface (%s)",
 			    iface->name, iface->lower->name);
 			continue;


### PR DESCRIPTION
There used to be specific exemptions carved out for "veth" and "dsa",
which were removed in b8db52bd7c7d ("interfaces/linux: blacklist some
drivers instead of whitelisting"). "veth" was restored in 2958b9d48940
("interfaces/linux: make veth special"). This commit restores the
whitelist for dsa devices as well.

---

My use case is a hardware platform where my SoC's ethernet interface (`eth0`) is connected to a DSA mv88e6xxx switch via RGMII (the switch then exposes two physical ports, `sw0` and `sw1`). Without this patch, `iflinux_add_physical` skips the `sw0` and `sw1` interfaces:
```
1970-01-01T00:06:40 [ DBG/interfaces] eth0 is a physical interface
1970-01-01T00:06:40 [ DBG/interfaces] skip sw0: there is a lower interface (eth0)
1970-01-01T00:06:40 [ DBG/interfaces] skip sw1: there is a lower interface (eth0)
```

With this patch applied, `sw0` and `sw1` are not rejected and I am allowed to configure them as valid ports.