### PR TITLE
netlink: handle blocking read from netlink socket

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,7 @@ lldpd (1.0.4)
   * Fix:
     + Better compliance for statsTLVsUnrecognizedTotal and
       statsAgeoutsTotal counters.
+    + On Linux, handle rare blocking case in Netlink code.
 
 lldpd (1.0.3)
   * Fix:

--- a/src/daemon/event.c
+++ b/src/daemon/event.c
@@ -756,8 +756,7 @@ levent_iface_subscribe(struct lldpd *cfg, int socket)
 {
 	log_debug("event", "subscribe to interface changes from socket %d",
 	    socket);
-	if (cfg->g_iface_cb == NULL)
-		levent_make_socket_nonblocking(socket);
+	levent_make_socket_nonblocking(socket);
 	cfg->g_iface_event = event_new(cfg->g_base, socket,
 	    EV_READ | EV_PERSIST, levent_iface_recv, cfg);
 	if (cfg->g_iface_event == NULL) {

--- a/src/daemon/lldpd.h
+++ b/src/daemon/lldpd.h
@@ -127,6 +127,9 @@ void	 levent_schedule_pdu(struct lldpd_hardware *);
 void	 levent_schedule_cleanup(struct lldpd *);
 int	 levent_make_socket_nonblocking(int);
 int	 levent_make_socket_blocking(int);
+#ifdef HOST_OS_LINUX
+void	 levent_recv_error(int, const char*);
+#endif
 
 /* lldp.c */
 int	 lldp_send_shutdown(PROTO_SEND_SIG);

--- a/src/daemon/netlink.c
+++ b/src/daemon/netlink.c
@@ -472,7 +472,7 @@ netlink_recv(struct lldpd *cfg,
 		};
 		flags = MSG_PEEK | MSG_TRUNC;
 retry:
-		len = recvmsg(s, &rtnl_reply, flags | MSG_DONTWAIT);
+		len = recvmsg(s, &rtnl_reply, flags);
 		if (len == -1) {
 			if (errno == EAGAIN || errno == EWOULDBLOCK) {
 				if (retry++ == 0) {


### PR DESCRIPTION
It seems it is possible to run into a condition where the netlink
socket is not available for read. Set the MSG_DONTWAIT flag and fetch
an error if there is any.

Fix #333