### PR TITLE
netlink: support VLAN-aware bridges

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 lldpd (1.0.5)
   * Changes:
     + Interface names are also matched for management addresses.
+    + Add support for VLAN-aware bridges for Linux (no range support).
 
 lldpd (1.0.4)
   * Changes:

--- a/src/client/display.c
+++ b/src/client/display.c
@@ -522,14 +522,16 @@ display_vlans(struct writer *w, lldpctl_atom_t *port)
 	lldpctl_atom_foreach(vlans, vlan) {
 		vid = lldpctl_atom_get_int(vlan,
 		    lldpctl_k_vlan_id);
-		if (pvid == vid)
-			foundpvid = 1;
 
 		tag_start(w, "vlan", "VLAN");
 		tag_attr(w, "vlan-id", "",
 		    lldpctl_atom_get_str(vlan, lldpctl_k_vlan_id));
-		if (pvid == vid)
+		if (pvid == vid) {
 			tag_attr(w, "pvid", "pvid", "yes");
+			foundpvid = 1;
+		} else {
+			tag_attr(w, "pvid", "pvid", "no");
+		}
 		tag_data(w, lldpctl_atom_get_str(vlan,
 			lldpctl_k_vlan_name));
 		tag_end(w);

--- a/src/daemon/interfaces-bsd.c
+++ b/src/daemon/interfaces-bsd.c
@@ -307,7 +307,7 @@ ifbsd_check_vlan(struct lldpd *cfg,
 	    "%s is VLAN %d of %s",
 	    vlan->name, vreq.vlr_tag, lower->name);
 	vlan->lower = lower;
-	vlan->vlanid = vreq.vlr_tag;
+	vlan->vlanids[0] = vreq.vlr_tag;
 	vlan->type |= IFACE_VLAN_T;
 }
 

--- a/src/daemon/interfaces-linux.c
+++ b/src/daemon/interfaces-linux.c
@@ -206,7 +206,7 @@ iflinux_is_vlan(struct lldpd *cfg,
 		}
 
 		iface->lower = lower;
-		iface->vlanid = ifv.u.VID;
+		iface->vlanids[0] = ifv.u.VID;
 		return 1;
 	}
 #endif

--- a/src/daemon/lldpd.h
+++ b/src/daemon/lldpd.h
@@ -313,7 +313,8 @@ struct interfaces_device {
 	int   flags;		/* Flags (IFF_*) */
 	int   mtu;		/* MTU */
 	int   type;		/* Type (see IFACE_*_T) */
-	int   vlanid;		/* If a VLAN, what is the VLAN ID? */
+	int   vlanids[10];	/* If a VLAN, what are the VLAN ID? */
+	int   pvid;		/* If a VLAN, what is the default VLAN? */
 	struct interfaces_device *lower; /* Lower interface (for a VLAN for example) */
 	struct interfaces_device *upper; /* Upper interface (for a bridge or a bond) */
 

--- a/src/lldpd-structs.c
+++ b/src/lldpd-structs.c
@@ -73,6 +73,7 @@ lldpd_vlan_cleanup(struct lldpd_port *port)
 		free(vlan);
 	}
 	TAILQ_INIT(&port->p_vlans);
+	port->p_pvid = 0;
 }
 
 void

--- a/tests/integration/fixtures/network.py
+++ b/tests/integration/fixtures/network.py
@@ -129,6 +129,20 @@ class LinksFactory(object):
         ipr.link('set', index=idx, state='up')
         return idx
 
+    def bridge_vlan(self, iface, vid, tagged=True, pvid=False, remove=False):
+        ipr = pyroute2.IPRoute()
+        idx = ipr.link_lookup(ifname=iface)[0]
+        flags = []
+        if not tagged:
+            flags.append('untagged')
+        if pvid:
+            flags.append('pvid')
+        if not remove:
+            ipr.vlan_filter('del', index=idx, vlan_info={"vid": 1})
+        ipr.vlan_filter('add' if not remove else 'del', index=idx,
+                        vlan_info={'vid': vid,
+                                   'flags': flags})
+
     def up(self, name):
         ipr = pyroute2.IPRoute()
         idx = ipr.link_lookup(ifname=name)[0]


### PR DESCRIPTION
This is work in progress. It seems to work, but I need to think a bit about the edge cases around polling `AF_BRIDGE` family (which was mostly excluded until now). Maybe more data should be ignored when family is `AF_BRIDGE`.