### PR TITLE
lldp: validate a bit more received LLDP frames

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ lldpd (1.0.5)
     + Interface names are also matched for management addresses.
     + On Linux, only register protocol handler for LLDP when only LLDP
       is enabled.
+    + Stricter on LLDP incoming frames validation.
 
 lldpd (1.0.4)
   * Changes:


### PR DESCRIPTION
Notably, we ensure the order and unicity of Chassis ID, Port ID and
TTL TLV. For Chassis ID and Port ID, we also ensure the maximum size
does not exceed 256.

Fix #351.