### PR TITLE
lldp: when receiving a shutdown LLDPU, don't clear chassis information

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@ lldpd (1.0.5)
     + On Linux, only register protocol handler for LLDP when only LLDP
       is enabled.
     + Stricter on LLDP incoming frames validation.
+  * Fix:
+    + Don't clear chassis TLV on shutdown LLDPDU.
 
 lldpd (1.0.4)
   * Changes:

--- a/src/daemon/lldpd.c
+++ b/src/daemon/lldpd.c
@@ -662,7 +662,14 @@ lldpd_decode(struct lldpd *cfg, char *frame, int s,
 		free(oport);
 	}
 	if (ochassis) {
-		lldpd_move_chassis(ochassis, chassis);
+		if (port->p_ttl == 0) {
+			/* Shutdown LLDPDU is special. We do not want to replace
+			 * the chassis. Free the new chassis (which is mostly empty) */
+			log_debug("decode", "received a shutdown LLDPDU");
+			lldpd_chassis_cleanup(chassis, 1);
+		} else {
+			lldpd_move_chassis(ochassis, chassis);
+		}
 		chassis = ochassis;
 	} else {
 		/* Chassis not known, add it */

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,3 +1,4 @@
 pyroute2==0.5.2
 pytest==3.10.1
 pytest-xdist==1.26.1
+scapy==2.4.3


### PR DESCRIPTION
The chassis may be shared with another port. When the MSAP is known
and we receive a shutdown LLDPDU, just leave the original chassis as
is instead of copying information from the new chassis to the old
chassis.

Fix #348.