### PR TITLE
LLDPD should document system refresh timer (tx-interval * 20)

### DIFF
--- a/src/client/lldpcli.8.in
+++ b/src/client/lldpcli.8.in
@@ -504,7 +504,11 @@ Force port description to the provided string.
 .Bd -ragged -offset XXXXXX
 Change transmit delay to the specified value in seconds. The transmit
 delay is the delay between two transmissions of LLDP PDU. The default
-value is 30 seconds.
+value is 30 seconds. Note:
+.Nm lldpd
+also starts another system based refresh timer on each port to detect
+changes such as a hostname. This is the value of the tx-interval
+multiplied by 20.
 .Ed
 
 .Cd configure


### PR DESCRIPTION
In LLDPD, each port has its own timer to catch port-related
changes and is modified by changing the tx-interval.

LLDPD also starts another system based refresh timer on each port
for changes like hostname. This is the tx-interval multiplied by
20.  This needs to be documented.

Signed-off-by: Sam Tannous <stannous@cumulusnetworks.com>