### PR TITLE
Fix for limitation of 10 VLANs for LLDP .1q feature

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ lldpd (1.0.5)
     + Add support for VLAN-aware bridges for Linux (no range support).
     + Add support for 802.3BT (no SNMP support).
     + Add support for millisecond-grained tx-interval (Jean-Pierre Tosoni).
+    + Use generic names for VLAN names, instead of interface names (eg
+      vlan100 instead of eth1.100).
   * Fix:
     + Don't clear chassis TLV on shutdown LLDPDU.
     + Don't require/display powerpairs for Dot3 power when device type

--- a/src/daemon/interfaces-bsd.c
+++ b/src/daemon/interfaces-bsd.c
@@ -307,7 +307,7 @@ ifbsd_check_vlan(struct lldpd *cfg,
 	    "%s is VLAN %d of %s",
 	    vlan->name, vreq.vlr_tag, lower->name);
 	vlan->lower = lower;
-	vlan->vlanids[0] = vreq.vlr_tag;
+	bitmap_set(vlan->vlan_bmap, vreq.vlr_tag);
 	vlan->type |= IFACE_VLAN_T;
 }
 

--- a/src/daemon/interfaces-linux.c
+++ b/src/daemon/interfaces-linux.c
@@ -222,7 +222,7 @@ iflinux_is_vlan(struct lldpd *cfg,
 		}
 
 		iface->lower = lower;
-		iface->vlanids[0] = ifv.u.VID;
+		bitmap_set(iface->vlan_bmap, ifv.u.VID);
 		return 1;
 	}
 #endif

--- a/src/daemon/lldpd.h
+++ b/src/daemon/lldpd.h
@@ -303,6 +303,11 @@ void     interfaces_update(struct lldpd *);
 #define IFACE_BOND_T     (1 << 2) /* Bond interface */
 #define IFACE_VLAN_T     (1 << 3) /* VLAN interface */
 #define IFACE_WIRELESS_T (1 << 4) /* Wireless interface */
+#define IFACE_BRIDGE_PORT_T (1 << 5) /* Bridge Port */
+#define IFACE_BOND_SLAVE_T (1 << 6) /* Bond slave */
+
+#define MAX_VLAN 4096
+#define VLAN_BITMAP_LEN (MAX_VLAN / 32)
 struct interfaces_device {
 	TAILQ_ENTRY(interfaces_device) next;
 	int   ignore;		/* Ignore this interface */
@@ -314,7 +319,7 @@ struct interfaces_device {
 	int   flags;		/* Flags (IFF_*) */
 	int   mtu;		/* MTU */
 	int   type;		/* Type (see IFACE_*_T) */
-	int   vlanids[10];	/* If a VLAN, what are the VLAN ID? */
+	uint32_t vlan_bmap[VLAN_BITMAP_LEN];	/* If a VLAN, what are the VLAN ID? */
 	int   pvid;		/* If a VLAN, what is the default VLAN? */
 	struct interfaces_device *lower; /* Lower interface (for a VLAN for example) */
 	struct interfaces_device *upper; /* Upper interface (for a bridge or a bond) */
@@ -383,6 +388,9 @@ struct interfaces_address_list *netlink_get_addresses(struct lldpd *);
 void netlink_cleanup(struct lldpd *);
 struct lldpd_netlink;
 #endif
+
+void bitmap_set(uint32_t *bmap, uint16_t vlan_id);
+int is_bitmap_empty(uint32_t *bmap);
 
 #ifndef HOST_OS_LINUX
 int ifbpf_phys_init(struct lldpd *, struct lldpd_hardware *);

--- a/src/daemon/netlink.c
+++ b/src/daemon/netlink.c
@@ -325,7 +325,7 @@ netlink_parse_afspec(struct interfaces_device *iff, struct rtattr *rta, int len)
 		rta = RTA_NEXT(rta, len);
 	}
 	/* All enbridged interfaces will have VLAN 1 by default, ignore it */
-	if (iff->vlan_bmap[0] == 1 && (num_bits_set(iff->vlan_bmap) == 1)
+	if (iff->vlan_bmap[0] == 2 && (num_bits_set(iff->vlan_bmap) == 1)
 			&& iff->pvid == 1) {
 		log_debug("netlink", "found only default VLAN 1 on interface %s, removing",
 		    iff->name ? iff->name : "(unknown)");

--- a/src/daemon/netlink.c
+++ b/src/daemon/netlink.c
@@ -75,19 +75,16 @@ is_bitmap_empty(uint32_t *bmap)
  * Calculate the number of bits set in the bitmap to get total
  * number of VLANs
  */
-static int
+static unsigned int
 num_bits_set(uint32_t *bmap)
 {
-	int num = 0;
-	int i, bit;
+	unsigned int num = 0;
 
-	for (i = 0; (i < VLAN_BITMAP_LEN); i++) {
-		if (!bmap[i])
-			continue;
-		for (bit = 0; bit < 32; bit++) {
-			if (bmap[i] & (1 << bit))
-				num++;
-		}
+	for (int i = 0; (i < VLAN_BITMAP_LEN); i++) {
+		uint32_t v = bmap[i];
+		v = v - ((v >> 1) & 0x55555555);
+		v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
+		num += (((v + (v >> 4)) & 0x0F0F0F0F) * 0x01010101) >> 24;
 	}
 
 	return num;

--- a/src/daemon/protocols/lldp.c
+++ b/src/daemon/protocols/lldp.c
@@ -518,6 +518,7 @@ end:
 	return 0;
 
 toobig:
+	log_info("lldp", "Cannot send LLDP packet for %s, Too big message", p_id);
 	free(packet);
 	return E2BIG;
 }

--- a/tests/integration/test_interfaces.py
+++ b/tests/integration/test_interfaces.py
@@ -83,7 +83,7 @@ def test_vlan_aware_bridge_with_vlan(lldpd1, lldpd, lldpcli, namespaces, links,
         out = lldpcli("-f", "keyvalue", "show", "neighbors", "details")
         assert out['lldp.eth0.port.descr'] == 'eth1'
         assert out['lldp.eth0.vlan'] == \
-            ['eth1.100', 'eth1.200', 'eth1.300']
+            ['vlan100', 'vlan200', 'vlan300']
         assert out['lldp.eth0.vlan.vlan-id'] == \
             ['100', '200', '300']
         assert out['lldp.eth0.vlan.pvid'] == \
@@ -217,10 +217,7 @@ def test_remove_vlan(lldpd1, lldpd, lldpcli, namespaces, links, kind):
     with namespaces(1):
         out = lldpcli("-f", "keyvalue", "show", "neighbors", "details")
         assert out['lldp.eth0.port.descr'] == 'eth1'
-        if kind != 'vlan-aware-bridge':
-            assert out['lldp.eth0.vlan'] == ['vlan400', 'vlan500']
-        else:
-            assert out['lldp.eth0.vlan'] == ['eth1.400', 'eth1.500']
+        assert out['lldp.eth0.vlan'] == ['vlan400', 'vlan500']
         assert out['lldp.eth0.vlan.vlan-id'] == ['400', '500']
         assert out['lldp.eth0.vlan.pvid'] == ['no', 'no']
 


### PR DESCRIPTION
Max 10 VLAN ids are supported on a port for .1q feature

Root Cause: All the VLANs learnt from netlink is dropped after 10 VLANs due
to the static array allocation of only 10 VLAN ids in the interface structure.
Beyond 10 VLAN membership for a port are ignored and error message gets
printed causing flooding of messages when hundreds of VLANs are configured.

Fix: Changed the static VLAN id array to VLAN id bitmap. With the bitmap all 4k
VLANs can be stored and learnt from netlink messages.
- Added a message to indicate when the LLDP packet is not sent out because
its too big. This will be helpful for user when too many VLANs are
configured and LLDP packets are not sent out.

Limitation: Even though the VLAN learning from netlink messages has been
alleviated, due to the LLDP message size around 380 VLANs can be advertised in
the packet. This number can vary based on the number of other TLVs being
advertised by LLDP.

vlan info shows interface_name.vlan-id which makes it look like sub
interface and causes confusion

Root Cause: Vlan name is sent as part of the .1q TLVs. But, the vlan name
format was <nterface-name>.<vlan-id> which makes it look like a sub-interface.

Fix: The vlan name cannot be removed from the vlan-info display since it is
sent/received as part of the .1q TLV in LLDP packet. But, changed the
vlan name format to vlan-<vlan-id> to avoid the confusion.
(cherry picked from commit 38db598121f5ce615f98d6cdaf41d5360c40dc3c)

Conflicts:
	src/daemon/interfaces-linux.c
	src/daemon/lldpd.h