### PR TITLE
Fix for extra VLANs from bridge sent in the LLDP message

### DIFF
--- a/src/daemon/interfaces.c
+++ b/src/daemon/interfaces.c
@@ -285,6 +285,14 @@ iface_append_vlan_to_lower(struct lldpd *cfg,
 	    "looking to apply VLAN %s to physical interface behind %s",
 	    vlan->name, upper->name);
 
+	/* Ignore the bridge interface since the bridge member interfaces may not
+	 * inherit all VLANs the bridge interface has */
+	if (upper->type & IFACE_BRIDGE_T) {
+		log_debug("interfaces", "VLAN %s ignored for bridge interface %s",
+		    vlan->name, upper->name);
+		return;
+	}
+
 	/* Easy: check if we have a lower interface. */
 	if (upper->lower) {
 		log_debug("interfaces", "VLAN %s on lower interface %s",

--- a/tests/integration/test_dot1.py
+++ b/tests/integration/test_dot1.py
@@ -11,7 +11,7 @@ class TestLldpDot1(object):
             lldpd()
         with namespaces(1):
             out = lldpcli("-f", "keyvalue", "show", "neighbors", "details")
-            assert out['lldp.eth0.vlan'] == 'vlan100'
+            assert out['lldp.eth0.vlan'] == 'vlan-100'
             assert out['lldp.eth0.vlan.vlan-id'] == '100'
 
     def test_several_vlans(self, lldpd1, lldpd, lldpcli, namespaces, links):
@@ -23,7 +23,7 @@ class TestLldpDot1(object):
             out = lldpcli("-f", "keyvalue", "show", "neighbors", "details")
             # We know that lldpd is walking interfaces in index order
             assert out['lldp.eth0.vlan'] == \
-                ['vlan100', 'vlan200', 'vlan300', 'vlan4000']
+                ['vlan-100', 'vlan-200', 'vlan-300', 'vlan-4000']
             assert out['lldp.eth0.vlan.vlan-id'] == \
                 ['100', '200', '300', '4000']
 

--- a/tests/integration/test_interfaces.py
+++ b/tests/integration/test_interfaces.py
@@ -57,7 +57,7 @@ def test_bridge_with_vlan(lldpd1, lldpd, lldpcli, namespaces, links, when):
         out = lldpcli("-f", "keyvalue", "show", "neighbors", "details")
         assert out['lldp.eth0.port.descr'] == 'eth1'
         assert out['lldp.eth0.vlan'] == \
-            ['vlan100', 'vlan200', 'vlan300']
+            ['vlan-100', 'vlan-200', 'vlan-300']
         assert out['lldp.eth0.vlan.vlan-id'] == \
             ['100', '200', '300']
 
@@ -216,7 +216,7 @@ def test_remove_vlan(lldpd1, lldpd, lldpcli, namespaces, links, kind):
         out = lldpcli("-f", "keyvalue", "show", "neighbors", "details")
         assert out['lldp.eth0.port.descr'] == 'eth1'
         if kind != 'vlan-aware-bridge':
-            assert out['lldp.eth0.vlan'] == ['vlan400', 'vlan500']
+            assert out['lldp.eth0.vlan'] == ['vlan-400', 'vlan-500']
         else:
             assert out['lldp.eth0.vlan'] == ['eth1.400', 'eth1.500']
         assert out['lldp.eth0.vlan.vlan-id'] == ['400', '500']

--- a/tests/integration/test_interfaces.py
+++ b/tests/integration/test_interfaces.py
@@ -83,7 +83,7 @@ def test_vlan_aware_bridge_with_vlan(lldpd1, lldpd, lldpcli, namespaces, links,
         out = lldpcli("-f", "keyvalue", "show", "neighbors", "details")
         assert out['lldp.eth0.port.descr'] == 'eth1'
         assert out['lldp.eth0.vlan'] == \
-            ['eth1.100', 'eth1.200', 'eth1.300']
+            ['vlan-100', 'vlan-200', 'vlan-300']
         assert out['lldp.eth0.vlan.vlan-id'] == \
             ['100', '200', '300']
         assert out['lldp.eth0.vlan.pvid'] == \
@@ -160,7 +160,7 @@ def test_bond_with_vlan(lldpd1, lldpd, lldpcli, namespaces, links, when):
         out = lldpcli("-f", "keyvalue", "show", "neighbors", "details")
         assert out['lldp.eth0.port.descr'] == 'eth1'
         assert out['lldp.eth0.vlan'] == \
-            ['vlan300', 'vlan301', 'vlan302', 'vlan303']
+            ['vlan-300', 'vlan-301', 'vlan-302', 'vlan-303']
         assert out['lldp.eth0.vlan.vlan-id'] == \
             ['300', '301', '302', '303']
 
@@ -181,7 +181,7 @@ def test_just_vlan(lldpd1, lldpd, lldpcli, namespaces, links, when):
     with namespaces(1):
         out = lldpcli("-f", "keyvalue", "show", "neighbors", "details")
         assert out['lldp.eth0.port.descr'] == 'eth1'
-        assert out['lldp.eth0.vlan'] == ['vlan300', 'vlan400']
+        assert out['lldp.eth0.vlan'] == ['vlan-300', 'vlan-400']
         assert out['lldp.eth0.vlan.vlan-id'] == ['300', '400']
 
 
@@ -218,7 +218,7 @@ def test_remove_vlan(lldpd1, lldpd, lldpcli, namespaces, links, kind):
         if kind != 'vlan-aware-bridge':
             assert out['lldp.eth0.vlan'] == ['vlan-400', 'vlan-500']
         else:
-            assert out['lldp.eth0.vlan'] == ['eth1.400', 'eth1.500']
+            assert out['lldp.eth0.vlan'] == ['vlan-400', 'vlan-500']
         assert out['lldp.eth0.vlan.vlan-id'] == ['400', '500']
         assert out['lldp.eth0.vlan.pvid'] == ['no', 'no']
 
@@ -252,7 +252,7 @@ def test_unenslave_bond_with_vlan(lldpd1, lldpd, lldpcli, namespaces, links):
     with namespaces(1):
         out = lldpcli("-f", "keyvalue", "show", "neighbors", "details")
         assert out['lldp.eth0.port.descr'] == 'eth1'
-        assert out['lldp.eth0.vlan'] == 'vlan400'
+        assert out['lldp.eth0.vlan'] == 'vlan-400'
         assert out['lldp.eth0.vlan.vlan-id'] == '400'
 
 
@@ -284,7 +284,7 @@ def test_down_then_up_with_vlan(lldpd1, lldpd, lldpcli, namespaces, links):
     with namespaces(1):
         out = lldpcli("-f", "keyvalue", "show", "neighbors", "details")
         assert out['lldp.eth0.port.descr'] == 'eth1'
-        assert out['lldp.eth0.vlan'] == ['vlan300', 'vlan400']
+        assert out['lldp.eth0.vlan'] == ['vlan-300', 'vlan-400']
         assert out['lldp.eth0.vlan.vlan-id'] == ['300', '400']
 
 


### PR DESCRIPTION
Extra VLANs that the bridge port is not part of are being advertised in LLDP message to the peer

Root Cause: The bridge member port lldp messages also includes all the VLANs
            that its master bridge in part of even though the port is not part
            of those VLANs. This happens because during netlink VLAN updates
            all the bridge members of a bridge are traversed and VLANs on the
            bridge are applied to its bridge members.

Fix: Added a check to ignore the bridge interfaces during processing/applying
     of VLAN updates from netlink messages and not propagate the VLANs
     configured against the bridges to its members.
(cherry picked from commit 607015aa407c4ef7c601d8cdbb801ab9e8a53eb1)