### PR TITLE
interfaces: don't modify chassis ID when overriden

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+lldpd (1.0.6)
+  * Fix:
+    + Do not loose chassis local information when interface status changes.
+
 lldpd (1.0.5)
   * Changes:
     + Interface names are also matched for management addresses.

--- a/src/daemon/interfaces.c
+++ b/src/daemon/interfaces.c
@@ -364,8 +364,12 @@ interfaces_helper_chassis(struct lldpd *cfg,
 		(LOCAL_CHASSIS(cfg)->c_cap_enabled == 0))
 	    LOCAL_CHASSIS(cfg)->c_cap_enabled = LLDP_CAP_STATION;
 
-	if (LOCAL_CHASSIS(cfg)->c_id != NULL &&
-	    LOCAL_CHASSIS(cfg)->c_id_subtype == LLDP_CHASSISID_SUBTYPE_LLADDR)
+	/* Do not modify the chassis if it's already set to a MAC address or if
+	 * it's set to a local address equal to the user-provided
+	 * configuration. */
+	if ((LOCAL_CHASSIS(cfg)->c_id != NULL &&
+	    LOCAL_CHASSIS(cfg)->c_id_subtype == LLDP_CHASSISID_SUBTYPE_LLADDR) ||
+	    cfg->g_config.c_cid_string != NULL)
 		return;		/* We already have one */
 
 	TAILQ_FOREACH(iface, interfaces, next) {

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -133,6 +133,21 @@ def test_overrided_chassisid(lldpd1, lldpd, lldpcli, namespaces):
         assert out['lldp.eth0.chassis.local'] == "Modified chassis ID"
 
 
+def test_overrided_chassisid_kept(lldpd1, lldpd, lldpcli, namespaces, links):
+    with namespaces(2):
+        lldpd()
+        lldpcli("configure", "system", "chassisid", "Modified chassis ID")
+        links.down("eth1")
+        time.sleep(1)
+        links.up("eth1")
+        time.sleep(1)
+        lldpcli("update")
+        time.sleep(1)
+    with namespaces(1):
+        out = lldpcli("-f", "keyvalue", "show", "neighbors")
+        assert out['lldp.eth0.chassis.local'] == "Modified chassis ID"
+
+
 def test_overrided_chassisid_reverse(lldpd1, lldpd, lldpcli, namespaces):
     with namespaces(2):
         lldpd()


### PR DESCRIPTION
If the chassis ID has been overriden by the user, do not modify it.

Fix #385