### PR TITLE
lib: introduce lldpctl_watch_callback2()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 lldpd (1.0.6)
   * Fix:
     + Do not loose chassis local information when interface status changes.
+  * Changes:
+    + Deprecate use of lldpctl_watch_callback(). Use
+      lldpctl_watch_callback2() instead.
 
 lldpd (1.0.5)
   * Changes:

--- a/src/client/display.c
+++ b/src/client/display.c
@@ -714,7 +714,7 @@ display_interface(lldpctl_conn_t *conn, struct writer *w, int hidden,
 
 	display_chassis(w, chassis, details);
 	display_port(w, port, details);
-	if (details && local)
+	if (details && local && conn)
 		display_local_ttl(w, conn, details);
 	if (details == DISPLAY_DETAILS) {
 		display_vlans(w, port);

--- a/src/client/show.c
+++ b/src/client/show.c
@@ -154,8 +154,7 @@ struct watcharg {
  * Callback for the next function to display a new neighbor.
  */
 static void
-watchcb(lldpctl_conn_t *conn,
-    lldpctl_change_t type,
+watchcb(lldpctl_change_t type,
     lldpctl_atom_t *interface,
     lldpctl_atom_t *neighbor,
     void *data)
@@ -201,7 +200,7 @@ watchcb(lldpctl_conn_t *conn,
 		break;
 	default: return;
 	}
-	display_interface(conn, w, 1, interface, neighbor,
+	display_interface(NULL, w, 1, interface, neighbor,
 	    cmdenv_get(env, "summary")?DISPLAY_BRIEF:
 	    cmdenv_get(env, "detailed")?DISPLAY_DETAILS:
 	    DISPLAY_NORMAL, protocol);
@@ -234,7 +233,7 @@ cmd_watch_neighbors(struct lldpctl_conn_t *conn, struct writer *w,
 	}
 
 	log_debug("lldpctl", "watch for neighbor changes");
-	if (lldpctl_watch_callback(conn, watchcb, &wa) < 0) {
+	if (lldpctl_watch_callback2(conn, watchcb, &wa) < 0) {
 		log_warnx("lldpctl", "unable to watch for neighbors. %s",
 		    lldpctl_last_strerror(conn));
 		return 0;

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -54,7 +54,7 @@ CLEANFILES = atom-glue.c
 # -version-number could be computed from -version-info, mostly major
 # is `current` - `age`, minor is `age` and revision is `revision' and
 # major.minor should be used when updaing lldpctl.map.
-liblldpctl_la_LDFLAGS = $(AM_LDFLAGS) -version-info 12:0:8
+liblldpctl_la_LDFLAGS = $(AM_LDFLAGS) -version-info 13:0:9
 liblldpctl_la_DEPENDENCIES = libfixedpoint.la
 
 if HAVE_LD_VERSION_SCRIPT

--- a/src/lib/atom.c
+++ b/src/lib/atom.c
@@ -314,6 +314,10 @@ _lldpctl_do_something(lldpctl_conn_t *conn,
 {
 	ssize_t rc;
 
+	if (conn->state == CONN_STATE_WATCHING)
+		/* The connection cannot be used anymore. */
+		return SET_ERROR(conn, LLDPCTL_ERR_INVALID_STATE);
+
 	if (conn->state == CONN_STATE_IDLE) {
 		/* We need to build the message to send, then send
 		 * it. */
@@ -371,6 +375,7 @@ lldpctl_watch_callback(lldpctl_conn_t *conn,
 	if (rc == 0) {
 		conn->watch_cb = cb;
 		conn->watch_data = data;
+		conn->state = CONN_STATE_WATCHING;
 	}
 	return rc;
 }
@@ -382,7 +387,7 @@ lldpctl_watch(lldpctl_conn_t *conn)
 
 	RESET_ERROR(conn);
 
-	if (conn->state != CONN_STATE_IDLE)
+	if (conn->state != CONN_STATE_WATCHING)
 		return SET_ERROR(conn, LLDPCTL_ERR_INVALID_STATE);
 
 	conn->watch_triggered = 0;

--- a/src/lib/atom.c
+++ b/src/lib/atom.c
@@ -381,6 +381,26 @@ lldpctl_watch_callback(lldpctl_conn_t *conn,
 }
 
 int
+lldpctl_watch_callback2(lldpctl_conn_t *conn,
+    lldpctl_change_callback2 cb,
+    void *data)
+{
+	int rc;
+
+	RESET_ERROR(conn);
+
+	rc = _lldpctl_do_something(conn,
+	    CONN_STATE_SET_WATCH_SEND, CONN_STATE_SET_WATCH_RECV, NULL,
+	    SUBSCRIBE, NULL, NULL, NULL, NULL);
+	if (rc == 0) {
+		conn->watch_cb2 = cb;
+		conn->watch_data = data;
+		conn->state = CONN_STATE_WATCHING;
+	}
+	return rc;
+}
+
+int
 lldpctl_watch(lldpctl_conn_t *conn)
 {
 	int rc = 0;

--- a/src/lib/atom.h
+++ b/src/lib/atom.h
@@ -65,6 +65,7 @@ struct lldpctl_conn_t {
 
 	/* Handling notifications */
 	lldpctl_change_callback watch_cb;
+	lldpctl_change_callback2 watch_cb2;
 	void *watch_data;
 	int watch_triggered;
 };

--- a/src/lib/atom.h
+++ b/src/lib/atom.h
@@ -54,6 +54,7 @@ struct lldpctl_conn_t {
 #define CONN_STATE_GET_CHASSIS_RECV	14
 #define CONN_STATE_GET_DEFAULT_PORT_SEND 15
 #define CONN_STATE_GET_DEFAULT_PORT_RECV 16
+#define CONN_STATE_WATCHING		17
 	int state;		/* Current state */
 	/* Data attached to the state. It is used to check that we are using the
 	 * same data as a previous call until the state machine goes to

--- a/src/lib/connection.c
+++ b/src/lib/connection.c
@@ -196,7 +196,7 @@ check_for_notification(lldpctl_conn_t *conn)
 	change = p;
 
 	/* We have a notification, call the callback */
-	if (conn->watch_cb) {
+	if (conn->watch_cb || conn->watch_cb2) {
 		switch (change->state) {
 		case NEIGHBOR_CHANGE_DELETED: type = lldpctl_c_deleted; break;
 		case NEIGHBOR_CHANGE_ADDED: type = lldpctl_c_added; break;
@@ -212,7 +212,10 @@ check_for_notification(lldpctl_conn_t *conn)
 		neighbor = _lldpctl_new_atom(conn, atom_port, 0,
 		    NULL, change->neighbor, NULL);
 		if (neighbor == NULL) goto end;
-		conn->watch_cb(conn, type, interface, neighbor, conn->watch_data);
+		if (conn->watch_cb)
+			conn->watch_cb(conn, type, interface, neighbor, conn->watch_data);
+		else
+			conn->watch_cb2(type, interface, neighbor, conn->watch_data);
 		conn->watch_triggered = 1;
 		goto end;
 	}

--- a/src/lib/connection.c
+++ b/src/lib/connection.c
@@ -262,7 +262,8 @@ lldpctl_recv(lldpctl_conn_t *conn, const uint8_t *data, size_t length)
 	return conn->input_buffer_len;
 }
 
-int lldpctl_process_conn_buffer(lldpctl_conn_t *conn)
+int
+lldpctl_process_conn_buffer(lldpctl_conn_t *conn)
 {
 	int rc;
 

--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -471,7 +471,8 @@ typedef enum {
  * reference to it, be sure to increment the reference count in the callback.
  *
  * @warning The provided connection should not be used at all. Do not use @c
- * lldpctl_atom_set_*() functions on @c interface or @c neighbor either.
+ * lldpctl_atom_set_*() functions on @c interface or @c neighbor either. If you
+ * do, you will get a @c LLDPCTL_ERR_INVALID_STATE error.
  *
  * @see lldpctl_watch_callback
  */
@@ -494,7 +495,8 @@ typedef void (*lldpctl_change_callback)(lldpctl_conn_t *conn,
  * LLDPCTL_ERR_WOULDBLOCK.
  *
  * @warning Once a callback is registered, the connection shouldn't be used for
- * anything else than receiving notifications.
+ * anything else than receiving notifications. If you do, you will get a @c
+ * LLDPCTL_ERR_INVALID_STATE error.
  */
 int lldpctl_watch_callback(lldpctl_conn_t *conn,
     lldpctl_change_callback cb,

--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -460,7 +460,7 @@ typedef enum {
 /**
  * Callback function invoked when a change is detected.
  *
- * @param conn      Connection with lldpd.
+ * @param conn      Connection with lldpd. Should not be used.
  * @param type      Type of change detected.
  * @param interface Physical interface on which the change has happened.
  * @param neighbor  Changed neighbor.
@@ -469,6 +469,9 @@ typedef enum {
  * The provided interface and neighbor atoms are stolen by the callback: their
  * reference count are decremented when the callback ends. If you want to keep a
  * reference to it, be sure to increment the reference count in the callback.
+ *
+ * @warning The provided connection should not be used at all. Do not use @c
+ * lldpctl_atom_set_*() functions on @c interface or @c neighbor either.
  *
  * @see lldpctl_watch_callback
  */
@@ -490,8 +493,8 @@ typedef void (*lldpctl_change_callback)(lldpctl_conn_t *conn,
  * and therefore will issue IO operations. The error code could then be @c
  * LLDPCTL_ERR_WOULDBLOCK.
  *
- * Once a callback is registered, the connection shouldn't be used for anything
- * else than receiving notifications.
+ * @warning Once a callback is registered, the connection shouldn't be used for
+ * anything else than receiving notifications.
  */
 int lldpctl_watch_callback(lldpctl_conn_t *conn,
     lldpctl_change_callback cb,

--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -449,7 +449,7 @@ void lldpctl_atom_dec_ref(lldpctl_atom_t *atom);
 /**
  * Possible events for a change (notification).
  *
- * @see lldpctl_watch_callback
+ * @see lldpctl_watch_callback2
  */
 typedef enum {
 	lldpctl_c_deleted,	/**< The neighbor has been deleted */
@@ -483,6 +483,48 @@ typedef void (*lldpctl_change_callback)(lldpctl_conn_t *conn,
     void *data);
 
 /**
+ * Callback function invoked when a change is detected.
+ *
+ * @param type      Type of change detected.
+ * @param interface Physical interface on which the change has happened.
+ * @param neighbor  Changed neighbor.
+ * @param data      Data provided when registering the callback.
+ *
+ * The provided interface and neighbor atoms are stolen by the callback: their
+ * reference count are decremented when the callback ends. If you want to keep a
+ * reference to it, be sure to increment the reference count in the callback.
+ *
+ * @see lldpctl_watch_callback2
+ */
+typedef void (*lldpctl_change_callback2)(lldpctl_change_t type,
+    lldpctl_atom_t *interface,
+    lldpctl_atom_t *neighbor,
+    void *data);
+
+/**
+ * Register a callback to be called on changes.
+ *
+ * @param conn Connection with lldpd.
+ * @param cb   Replace the current callback with the provided one.
+ * @param data Data that will be passed to the callback.
+ * @return 0 in case of success or -1 in case of errors.
+ *
+ * This function will register the necessity to push neighbor changes to lldpd
+ * and therefore will issue IO operations. The error code could then be @c
+ * LLDPCTL_ERR_WOULDBLOCK.
+ *
+ * @warning Once a callback is registered, the connection shouldn't be used for
+ * anything else than receiving notifications. If you do, you will get a @c
+ * LLDPCTL_ERR_INVALID_STATE error.
+ *
+ * @deprecated This function is deprecated and lldpctl_watch_callback2 should be
+ * used instead.
+ */
+int lldpctl_watch_callback(lldpctl_conn_t *conn,
+    lldpctl_change_callback cb,
+    void *data) __attribute__ ((deprecated));
+
+/**
  * Register a callback to be called on changes.
  *
  * @param conn Connection with lldpd.
@@ -498,8 +540,8 @@ typedef void (*lldpctl_change_callback)(lldpctl_conn_t *conn,
  * anything else than receiving notifications. If you do, you will get a @c
  * LLDPCTL_ERR_INVALID_STATE error.
  */
-int lldpctl_watch_callback(lldpctl_conn_t *conn,
-    lldpctl_change_callback cb,
+int lldpctl_watch_callback2(lldpctl_conn_t *conn,
+    lldpctl_change_callback2 cb,
     void *data);
 
 /**

--- a/src/lib/lldpctl.map
+++ b/src/lib/lldpctl.map
@@ -1,3 +1,8 @@
+LIBLLDPCTL_4.9 {
+ global:
+  lldpctl_watch_callback2;
+};
+
 LIBLLDPCTL_4.8 {
  global:
   lldpctl_get_default_port;


### PR DESCRIPTION
This is similar to `lldpctl_watch_callback()` (which is getting
deprecated), except the callback won't receive the current connection.
This prevents a user to use the connection which is unusable because
it is now dedicated to watch events.

Minor ABI dump due to new function, but everything is
backward-compatible, except you may now get an error if you use the
connection while watching (but this was already not supported).

Fix #380