### PR TITLE
#403 ports: make possible sending LLDP frames on a specified VLAN

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,7 @@ lldpd (1.0.6)
     + Deprecate use of lldpctl_watch_callback(). Use
       lldpctl_watch_callback2() instead.
     + Upgrade embedded libevent to 2.1.11-stable
+    + Add support of sending LLDP frames on a configured VLAN
 
 lldpd (1.0.5)
   * Changes:

--- a/src/client/display.c
+++ b/src/client/display.c
@@ -343,6 +343,9 @@ display_autoneg(struct writer * w, int advertised, int bithd, int bitfd, char *d
 static void
 display_port(struct writer *w, lldpctl_atom_t *port, int details)
 {
+	int vlan_tx_tag;
+	char buf[5]; /* should be enough for printing */
+
 	tag_start(w, "port", "Port");
 	tag_start(w, "id", "PortID");
 	tag_attr (w, "type", "",
@@ -352,6 +355,18 @@ display_port(struct writer *w, lldpctl_atom_t *port, int details)
 
 	tag_datatag(w, "descr", "PortDescr",
 	    lldpctl_atom_get_str(port, lldpctl_k_port_descr));
+
+	if ((vlan_tx_tag = lldpctl_atom_get_int(port, lldpctl_k_port_vlan_tx)) != -1) {
+		tag_start(w, "vlanTX", "VlanTX");
+		snprintf(buf, sizeof(buf), "%d", vlan_tx_tag & 0xfff);
+		tag_attr (w, "id", "VID", buf);
+		snprintf(buf, sizeof(buf), "%d", (vlan_tx_tag >> 13) & 0x7);
+		tag_attr (w, "prio", "Prio", buf);
+		snprintf(buf, sizeof(buf), "%d", (vlan_tx_tag >> 12) & 0x1);
+		tag_attr (w, "dei", "DEI", buf);
+		tag_end(w);
+	}
+
 	if (details &&
 	    lldpctl_atom_get_int(port, lldpctl_k_port_ttl) > 0)
 		tag_datatag(w, "ttl", "TTL",

--- a/src/client/lldpcli.8.in
+++ b/src/client/lldpcli.8.in
@@ -551,6 +551,22 @@ flag), setting any transmit mode won't have any effect.
 .Ed
 
 .Cd configure
+.Op ports Ar ethX Op ,...
+.Cd lldp
+.Cd vlan-tx Ar vlan_id
+.Op Cd prio Ar priority Op Cd dei Ar dei
+.Bd -ragged -offset XXXXXX
+Configure the given port to send LLDP frames over a specified VLAN. With VLAN Identifier (VID) as
+.Ar vlan_id ,
+Priority Code Point (PCP) as
+.Ar priority ,
+and Drop Eligible Indicator (DEI) as
+.Ar dei .
+.Nm lldpd
+accepts LLDP frames on all VLANs.
+.Ed
+
+.Cd configure
 .Cd lldp custom-tlv
 .Op Cd add | replace
 .Cd oui Ar oui

--- a/src/daemon/client.c
+++ b/src/daemon/client.c
@@ -390,6 +390,10 @@ _client_handle_set_port(struct lldpd *cfg,
 		port->p_disable_rx = port->p_disable_tx = 1;
 		break;
 	}
+	if (set->vlan_tx_enabled >= -1) {
+		port->p_vlan_tx_enabled = set->vlan_tx_enabled;
+		port->p_vlan_tx_tag = set->vlan_tx_tag;
+	}
 #ifdef ENABLE_LLDPMED
 	if (set->med_policy && set->med_policy->type > 0) {
 		log_debug("rpc", "requested change to MED policy");

--- a/src/daemon/protocols/lldp.c
+++ b/src/daemon/protocols/lldp.c
@@ -107,7 +107,21 @@ static int _lldp_send(struct lldpd *global,
 	      /* LLDP multicast address */
 	      POKE_BYTES(mcastaddr, ETHER_ADDR_LEN) &&
 	      /* Source MAC address */
-	      POKE_BYTES(&hardware->h_lladdr, ETHER_ADDR_LEN) &&
+	      POKE_BYTES(&hardware->h_lladdr, ETHER_ADDR_LEN)))
+		goto toobig;
+
+	/* Insert VLAN tag if needed */
+	if (port->p_vlan_tx_enabled) {
+		if (!(
+		     /* VLAN ethertype */
+		     POKE_UINT16(ETHERTYPE_VLAN) &&
+		     /* VLAN Tag Control Information (TCI) */
+		     /* Priority(3bits) | DEI(1bit) | VID(12bit) */
+		     POKE_UINT16(port->p_vlan_tx_tag)))
+			goto toobig;
+	}
+
+	if (!(
 	      /* LLDP frame */
 	      POKE_UINT16(ETHERTYPE_LLDP)))
 		goto toobig;

--- a/src/lib/atoms/port.c
+++ b/src/lib/atoms/port.c
@@ -349,6 +349,8 @@ _lldpctl_atom_set_atom_port(lldpctl_atom_t *atom, lldpctl_key_t key, lldpctl_ato
 		return NULL;
 	}
 
+	set.vlan_tx_enabled = -1;
+
 	switch (key) {
 	case lldpctl_k_port_id:
 		set.local_id = p->port->p_id;
@@ -358,6 +360,10 @@ _lldpctl_atom_set_atom_port(lldpctl_atom_t *atom, lldpctl_key_t key, lldpctl_ato
 		break;
 	case lldpctl_k_port_status:
 		set.rxtx = LLDPD_RXTX_FROM_PORT(p->port);
+		break;
+	case lldpctl_k_port_vlan_tx:
+		set.vlan_tx_tag = p->port->p_vlan_tx_tag;
+		set.vlan_tx_enabled = p->port->p_vlan_tx_enabled;
 		break;
 #ifdef ENABLE_DOT3
 	case lldpctl_k_port_dot3_power:
@@ -520,6 +526,13 @@ _lldpctl_atom_set_int_port(lldpctl_atom_t *atom, lldpctl_key_t key,
 			port->p_disable_rx = !LLDPD_RXTX_RXENABLED(value);
 			port->p_disable_tx = !LLDPD_RXTX_TXENABLED(value);
 			break;
+		case lldpctl_k_port_vlan_tx:
+			if (value > -1) {
+				port->p_vlan_tx_tag = value;
+				port->p_vlan_tx_enabled = 1;
+			} else
+				port->p_vlan_tx_enabled = 0;
+			break;
 		default:
 			SET_ERROR(atom->conn, LLDPCTL_ERR_NOT_EXIST);
 			return NULL;
@@ -622,6 +635,8 @@ _lldpctl_atom_get_int_port(lldpctl_atom_t *atom, lldpctl_key_t key)
 		return port->p_id_subtype;
 	case lldpctl_k_port_hidden:
 		return port->p_hidden_in;
+	case lldpctl_k_port_vlan_tx:
+		return port->p_vlan_tx_enabled ? port->p_vlan_tx_tag : -1;
 #ifdef ENABLE_DOT3
 	case lldpctl_k_port_dot3_mfs:
 		if (port->p_mfs > 0)

--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -738,6 +738,7 @@ typedef enum {
 	lldpctl_k_port_status,	   /**< `(IS,WO)` Operational status of this (local) port */
 	lldpctl_k_port_chassis,	   /**< `(A)` Chassis associated to the port */
 	lldpctl_k_port_ttl,        /**< `(I)` TTL for port, 0 if info is attached to chassis */
+	lldpctl_k_port_vlan_tx,    /**< `(I,W)` VLAN tag for TX on port, -1 VLAN disabled */
 
 	lldpctl_k_port_dot3_mfs = 1300,	   /**< `(I)` MFS */
 	lldpctl_k_port_dot3_aggregid,   /**< `(I)` Port aggregation ID */

--- a/src/lldpd-structs.h
+++ b/src/lldpd-structs.h
@@ -274,6 +274,8 @@ struct lldpd_port {
 	int			 p_descr_force; /* Description has been forced by user */
 	u_int16_t		 p_mfs;
 	u_int16_t		 p_ttl; /* TTL for remote port */
+	int			 p_vlan_tx_tag;
+	int			 p_vlan_tx_enabled;
 
 #ifdef ENABLE_DOT3
 	/* Dot3 stuff */
@@ -341,6 +343,8 @@ struct lldpd_port_set {
 	char *local_id;
 	char *local_descr;
 	int rxtx;
+	int vlan_tx_tag;
+	int vlan_tx_enabled;
 #ifdef ENABLE_LLDPMED
 	struct lldpd_med_policy *med_policy;
 	struct lldpd_med_loc    *med_location;

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -397,6 +397,22 @@ def test_port_status_disabled(lldpd, lldpcli, namespaces, links):
         assert out == {}
 
 
+def test_port_vlan_tx(lldpd1, lldpd, lldpcli, namespaces):
+    with namespaces(1):
+        lldpd()
+        lldpcli("configure", "ports", "eth0", "lldp", "vlan-tx", "100", "priority", "5", "dei", "1")
+        out = lldpcli("-f", "keyvalue", "show", "interfaces", "ports", "eth0")
+        assert out["lldp.eth0.port.vlanTX.id"] == '100'
+        assert out["lldp.eth0.port.vlanTX.prio"] == '5'
+        assert out["lldp.eth0.port.vlanTX.dei"] == '1'
+        # unconfigure VLAN TX
+        lldpcli("unconfigure", "ports", "eth0", "lldp", "vlan-tx")
+        out = lldpcli("-f", "keyvalue", "show", "interfaces", "ports", "eth0")
+        assert not "lldp.eth0.port.vlanTX.id" in out
+        assert not "lldp.eth0.port.vlanTX.prio" in out
+        assert not "lldp.eth0.port.vlanTX.dei" in out
+
+
 def test_set_interface_alias(lldpd1, lldpd, lldpcli, namespaces):
     with namespaces(1):
         lldpcli("configure", "system", "interface", "description")


### PR DESCRIPTION
The current limitation is that frames are sent only on one VLAN per port.