### PR TITLE
interfaces: listen to all incoming packets on Linux, not just LLDP ones

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+lldpd (1.0.7)
+  * Fix:
+    + Do not listen only to LLDP packets on Linux. When an interface
+      is enslaved to an Open vSwitch, incoming packets are missed.
+
 lldpd (1.0.6)
   * Fix:
     + Do not loose chassis local information when interface status changes.

--- a/src/daemon/interfaces-bpf.c
+++ b/src/daemon/interfaces-bpf.c
@@ -34,7 +34,7 @@ ifbpf_phys_init(struct lldpd *cfg,
 
 	log_debug("interfaces", "initialize ethernet device %s",
 	    hardware->h_ifname);
-	if ((fd = priv_iface_init(hardware->h_ifindex, hardware->h_ifname, 0)) == -1)
+	if ((fd = priv_iface_init(hardware->h_ifindex, hardware->h_ifname)) == -1)
 		return -1;
 
 	/* Allocate receive buffer */

--- a/src/daemon/lldpd.h
+++ b/src/daemon/lldpd.h
@@ -201,8 +201,8 @@ char   	*priv_gethostname(void);
 int    	 priv_open(char*);
 void	 asroot_open(void);
 #endif
-int    	 priv_iface_init(int, char *, int);
-int	 asroot_iface_init_os(int, char *, int *, int);
+int    	 priv_iface_init(int, char *);
+int	 asroot_iface_init_os(int, char *, int *);
 int	 priv_iface_multicast(const char *, const u_int8_t *, int);
 int	 priv_iface_description(const char *, const char *);
 int	 asroot_iface_description_os(const char *, const char *);

--- a/src/daemon/priv-bsd.c
+++ b/src/daemon/priv-bsd.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 int
-asroot_iface_init_os(int ifindex, char *name, int *fd, int proto)
+asroot_iface_init_os(int ifindex, char *name, int *fd)
 {
 	int enable, required, rc;
 	struct bpf_insn filter[] = { LLDPD_FILTER_F };

--- a/src/daemon/priv-linux.c
+++ b/src/daemon/priv-linux.c
@@ -115,12 +115,12 @@ asroot_open()
 }
 
 int
-asroot_iface_init_os(int ifindex, char *name, int *fd, int proto)
+asroot_iface_init_os(int ifindex, char *name, int *fd)
 {
 	int rc;
 	/* Open listening socket to receive/send frames */
 	if ((*fd = socket(PF_PACKET, SOCK_RAW,
-		    htons(proto))) < 0) {
+		    htons(ETH_P_ALL))) < 0) {
 		rc = errno;
 		return rc;
 	}

--- a/src/daemon/priv.c
+++ b/src/daemon/priv.c
@@ -120,7 +120,7 @@ priv_gethostname()
 
 
 int
-priv_iface_init(int index, char *iface, int proto)
+priv_iface_init(int index, char *iface)
 {
 	int rc;
 	char dev[IFNAMSIZ] = {};
@@ -129,7 +129,6 @@ priv_iface_init(int index, char *iface, int proto)
 	must_write(PRIV_UNPRIVILEGED, &index, sizeof(int));
 	strlcpy(dev, iface, IFNAMSIZ);
 	must_write(PRIV_UNPRIVILEGED, dev, IFNAMSIZ);
-	must_write(PRIV_UNPRIVILEGED, &proto, sizeof(int));
 	priv_wait();
 	must_read(PRIV_UNPRIVILEGED, &rc, sizeof(int));
 	if (rc != 0) return -1;
@@ -251,15 +250,13 @@ asroot_iface_init()
 {
 	int rc = -1, fd = -1;
 	int ifindex;
-	int proto;
 	char name[IFNAMSIZ];
 	must_read(PRIV_PRIVILEGED, &ifindex, sizeof(ifindex));
 	must_read(PRIV_PRIVILEGED, &name, sizeof(name));
 	name[sizeof(name) - 1] = '\0';
-	must_read(PRIV_PRIVILEGED, &proto, sizeof(proto));
 
 	TRACE(LLDPD_PRIV_INTERFACE_INIT(name));
-	rc = asroot_iface_init_os(ifindex, name, &fd, proto);
+	rc = asroot_iface_init_os(ifindex, name, &fd);
 	must_write(PRIV_PRIVILEGED, &rc, sizeof(rc));
 	if (rc == 0 && fd >=0) send_fd(PRIV_PRIVILEGED, fd);
 	if (fd >= 0) close(fd);


### PR DESCRIPTION
This mostly reverts fc5526dae75f. Listening only on ETH_P_LLDP makes
us miss incoming packets on enslaved interfaces to an Open vSwitch.
Therefore, prefer listening to ETH_P_ALL instead of ETH_P_LLDP. It is
likely that enslaved interfaces do not fully process Ethernet packets
and `type` is not correctly filled.

Fix #413