### PR TITLE
Add missing compat.h header under src/client/(kv,text,xml)_writer.c

### DIFF
--- a/src/client/kv_writer.c
+++ b/src/client/kv_writer.c
@@ -21,6 +21,7 @@
 #include <string.h>
 
 #include "writer.h"
+#include "../compat/compat.h"
 #include "../log.h"
 
 #define SEP '.'

--- a/src/client/text_writer.c
+++ b/src/client/text_writer.c
@@ -21,6 +21,7 @@
 #include <string.h>
 
 #include "writer.h"
+#include "../compat/compat.h"
 #include "../log.h"
 
 static char sep[] =

--- a/src/client/xml_writer.c
+++ b/src/client/xml_writer.c
@@ -30,6 +30,7 @@
 #endif
 
 #include "writer.h"
+#include "../compat/compat.h"
 #include "../log.h"
 
 struct xml_writer_private {


### PR DESCRIPTION
Under certain conditions, build would fail due to a missing reference to #include "../compat/compat.h" in text_writer.c, kv_writer.c and xml_writer.c.

Build system was running macOS 15.7.1 with Xcode, and CC=gcc as an alias to clang:
xndr$ gcc --version
Apple clang version 15.0.0 (clang-1500.1.0.2.5)
Target: x86_64-apple-darwin24.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

Build errors:
---------------
lldpd-1.0.20/src/client/text_writer.c:157:9: fatal error: call to undeclared function 'rpl_malloc'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        priv = malloc(sizeof(*priv));
               ^
../../config.h:316:16: note: expanded from macro 'malloc' #define malloc rpl_malloc
               ^
1 error generated.
make[2]: *** [lldpcli-text_writer.o] Error 1
make[1]: *** [install-recursive] Error 1
make: *** [stamp-x86_64] Error 2
---------------
lldpd-1.0.20/src/client/kv_writer.c:41:19: fatal error: call to undeclared function 'rpl_malloc'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if ((newprefix = malloc(s + 1)) == NULL) fatal(NULL, NULL);
                         ^
../../config.h:316:16: note: expanded from macro 'malloc' #define malloc rpl_malloc
               ^
1 error generated.
make[2]: *** [lldpcli-kv_writer.o] Error 1
make[1]: *** [install-recursive] Error 1
make: *** [stamp-x86_64] Error 2
---------------
lldpd-1.0.20/src/client/xml_writer.c:139:9: fatal error: call to undeclared function 'rpl_malloc'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        priv = malloc(sizeof(*priv));
               ^
../../config.h:316:16: note: expanded from macro 'malloc' #define malloc rpl_malloc
               ^
1 error generated.
make[2]: *** [lldpcli-xml_writer.o] Error 1
make[1]: *** [install-recursive] Error 1
make: *** [stamp-x86_64] Error 2