### PR TITLE
liblldpctl: Fix const correctness of the receive callback

### DIFF
--- a/src/lib/connection.c
+++ b/src/lib/connection.c
@@ -61,7 +61,7 @@ sync_send(lldpctl_conn_t *lldpctl, const uint8_t *data, size_t length, void *use
 
 /* Statically receive data from remote end. */
 static ssize_t
-sync_recv(lldpctl_conn_t *lldpctl, const uint8_t *data, size_t length, void *user_data)
+sync_recv(lldpctl_conn_t *lldpctl, uint8_t *data, size_t length, void *user_data)
 {
 	struct lldpctl_conn_sync_t *conn = user_data;
 	ssize_t nb = 0;
@@ -92,8 +92,7 @@ sync_recv(lldpctl_conn_t *lldpctl, const uint8_t *data, size_t length, void *use
 
 		if (fds[1].revents & POLLIN) {
 			/* Message from daemon. */
-			if ((nb = read(conn->fd, (unsigned char *)data + offset,
-				 remain)) == -1) {
+			if ((nb = read(conn->fd, data + offset, remain)) == -1) {
 				if (errno == EAGAIN || errno == EINTR) continue;
 				return LLDPCTL_ERR_CALLBACK_FAILURE;
 			}

--- a/src/lib/lldpctl.h
+++ b/src/lib/lldpctl.h
@@ -129,7 +129,7 @@ typedef ssize_t (*lldpctl_send_callback)(lldpctl_conn_t *conn, const uint8_t *da
  *         @c LLDPCTL_ERR_CALLBACK_FAILURE for other errors or @c
  *         LLDPCTL_ERR_EOF if end of file was reached.
  */
-typedef ssize_t (*lldpctl_recv_callback)(lldpctl_conn_t *conn, const uint8_t *data,
+typedef ssize_t (*lldpctl_recv_callback)(lldpctl_conn_t *conn, uint8_t *data,
     size_t length, void *user_data);
 
 /**


### PR DESCRIPTION
In order to write data into the buffer provided to the receive callback, it needs to be mutable. 